### PR TITLE
Make haproxy server backend id unique

### DIFF
--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -62,5 +62,5 @@ backend {{ $app.EscapedId }}-cluster
         option httpclose
         option forwardfor
         {{ range $page, $task := .Tasks }}
-        server {{ $app.EscapedId}}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ end }}
+        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ end }}
 {{ end }}


### PR DESCRIPTION
With the old haproxy configuration the server backend ids collide if the
same port is chosen by Marathon/Mesos on different hosts. This patch adds
the host name itself to the id to make them unique even with the same port.
