### PR TITLE
Make bamboo verbose on haproxy reload errors

### DIFF
--- a/services/event_bus/event_handler.go
+++ b/services/event_bus/event_handler.go
@@ -87,9 +87,12 @@ func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) bool {
 		err := ioutil.WriteFile(conf.HAProxy.OutputPath, []byte(newContent), 0666)
 		if err != nil { log.Fatalf("Failed to write template on path: %s", err) }
 
-		execCommand(conf.HAProxy.ReloadCommand)
-
-		log.Println("HAProxy: Configuration updated")
+		err = execCommand(conf.HAProxy.ReloadCommand)
+		if err != nil {
+			log.Fatalf("HAProxy: update failed\n")
+		} else {
+			log.Println("HAProxy: Configuration updated")
+		}
 		return true
 	} else {
 		log.Println("HAProxy: Same content, no need to reload")
@@ -97,10 +100,12 @@ func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) bool {
 	}
 }
 
-func execCommand(cmd string) {
-	_, err := exec.Command("sh", "-c", cmd).Output()
+func execCommand(cmd string) error {
+	log.Printf("Exec cmd: %s \n", cmd)
+	output, err := exec.Command("sh", "-c", cmd).CombinedOutput()
 	if err != nil {
 		log.Println(err.Error())
+		log.Println("Output:\n" + string(output[:]))
 	}
-	log.Printf("Exec cmd: %s \n", cmd)
+	return err
 }


### PR DESCRIPTION
On haproxy reload errors, only the exit status was printed, no "Exec cmd.." and not stdout/stderr of the command, i.e.:

```
2014/10/20 13:02:31.794232 exit status 1
2014/10/20 13:02:31.794513 HAProxy: Configuration updated
```

This patch changes the error output into:

```
2014/10/20 13:02:31.767447 Exec cmd: read PIDS < /var/run/haproxy.pid; haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $PIDS && while ps -p $PIDS; do sleep 0.2; done 
2014/10/20 13:02:31.794232 exit status 1
2014/10/20 13:02:31.794329 Output:
[ALERT] 292/130231 (9426) : parsing [/etc/haproxy/haproxy.cfg:38] : unknown keyword 'asdf' in 'defaults' section
[ALERT] 292/130231 (9426) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
[ALERT] 292/130231 (9426) : Fatal errors found in configuration.

2014/10/20 13:02:31.794513 HAProxy: update failed
```

Fixes #44
