### PR TITLE
do not preappend app ids with :: so that we can do routing based on the ...

### DIFF
--- a/services/marathon/marathon.go
+++ b/services/marathon/marathon.go
@@ -170,7 +170,7 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 			// Since Marathon 0.7, apps are namespaced with path
 			Id: appPath,
 			// Used for template
-			EscapedId:       strings.Replace(appId, "/", "::", -1),
+			EscapedId:       strings.Replace(appId, "/", "", -1),
 			Tasks:           simpleTasks,
 			HealthCheckPath: parseHealthCheckPath(marathonApps[appId].HealthChecks),
 		}


### PR DESCRIPTION
...app id as a host header

We would like to do routing based on the application id as a host header like so:

acl devint-widgetshop-api-aclrule  hdr_beg(host) -m beg -i devint-widgetshop-api

To do this it would be great if the escaped app id was not preappended with :: . 

I thought about adding another field to the struct but I couldn't think of a good reason why it is preappended with :: in the first place? 

Thanks!
