### PR TITLE
Export Marathon app env variables to the template environment

### DIFF
--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -25,11 +25,6 @@ defaults
         timeout client  50000
         timeout server  50000
 
-        stats enable
-        # CHANGE: Your stats credentials
-        stats auth admin:admin
-        stats uri /haproxy_stats
-
         errorfile 400 /etc/haproxy/errors/400.http
         errorfile 403 /etc/haproxy/errors/403.http
         errorfile 408 /etc/haproxy/errors/408.http
@@ -53,9 +48,20 @@ frontend http-in
         use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule
         {{ end }} {{ end }}
 
-{{ range $index, $app := .Apps }}
-backend {{ $app.EscapedId }}-cluster
-        {{ if $app.HealthCheckPath }}
+        stats enable
+        # CHANGE: Your stats credentials
+        stats auth admin:admin
+        stats uri /haproxy_stats
+
+{{ range $index, $app := .Apps }} {{ if $app.Env.BAMBOO_TCP_PORT }}
+listen {{ $app.EscapedId }}-cluster-tcp :{{ $app.Env.BAMBOO_TCP_PORT }}
+        mode tcp
+        option tcplog
+        balance roundrobin
+        {{ range $page, $task := .Tasks }}
+        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ end }}
+{{ end }}
+backend {{ $app.EscapedId }}-cluster{{ if $app.HealthCheckPath }}
         option httpchk GET {{ $app.HealthCheckPath }}
         {{ end }}
         balance leastconn

--- a/services/marathon/marathon.go
+++ b/services/marathon/marathon.go
@@ -22,6 +22,7 @@ type App struct {
 	HealthCheckPath string
 	Tasks           []Task
 	ServicePort     int
+	Env             map[string]string
 }
 
 type AppList []App
@@ -72,9 +73,10 @@ type MarathonApps struct {
 }
 
 type MarathonApp struct {
-	Id           string         `json:id`
-	HealthChecks []HealthChecks `json:healthChecks`
-	Ports        []int          `json:ports`
+	Id           string            `json:id`
+	HealthChecks []HealthChecks    `json:healthChecks`
+	Ports        []int             `json:ports`
+	Env          map[string]string `json:env`
 }
 
 type HealthChecks struct {
@@ -173,6 +175,7 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 			EscapedId:       strings.Replace(appId, "/", "::", -1),
 			Tasks:           simpleTasks,
 			HealthCheckPath: parseHealthCheckPath(marathonApps[appId].HealthChecks),
+			Env:             marathonApps[appId].Env,
 		}
 
 		if len(marathonApps[appId].Ports) > 0 {


### PR DESCRIPTION
The first patch adds the $app.Env map in the template environment.

This mechanism is used in the second patch to add TCP support by setting the BAMBOO_TCP_PORT variable in the application definition. This leads to a "mode tcp" section for that app in the haproxy configuration with the value of BAMBOO_TCP_PORT as the port to listen on.