### PR TITLE
Replace runtime.Caller call with osext.ExecutableFolder

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3,6 +3,11 @@
 	"GoVersion": "go1.3.3",
 	"Deps": [
 		{
+			"ImportPath": "bitbucket.org/kardianos/osext",
+			"Comment": "null-15",
+			"Rev": "44140c5fc69ecf1102c5ef451d73cd98ef59b178"
+		},
+		{
 			"ImportPath": "github.com/natefinch/lumberjack",
 			"Comment": "v1.0-12-gd28785c",
 			"Rev": "d28785c2f27cd682d872df46ccd8232843629f54"

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"syscall"
 	"time"
-	"path"
-	"runtime"
 
+	"bitbucket.org/kardianos/osext"
 	lumberjack "github.com/natefinch/lumberjack"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/zenazn/goji"
@@ -102,8 +102,11 @@ func initServer(conf *configuration.Configuration, conn *zk.Conn, eventBus *even
 
 // Get current executable folder path
 func executableFolder() string {
-	_, filename, _, _ := runtime.Caller(1)
-	return path.Dir(filename)
+	folderPath, err := osext.ExecutableFolder()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return folderPath
 }
 
 func registerMarathonEvent(conf *configuration.Configuration) {


### PR DESCRIPTION
The former returns the filename of the source file, not the executable, at least
when cross-compiling from Mac to Linux. The later works fine.