### PR TITLE
Use container $HOST environment variable as BAMBOO_ENDPOINT if AUTO_BAMB...

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Environment Variable | Corresponds To
 `HAPROXY_TEMPLATE_PATH` | HAProxy.TemplatePath
 `HAPROXY_OUTPUT_PATH` | HAProxy.OutputPath
 `HAPROXY_RELOAD_CMD` | HAProxy.ReloadCommand
+`BAMBOO_DOCKER_AUTO_HOST` | Sets `BAMBOO_ENDPOINT=$HOST` when Bamboo container starts. Can be any value.
 
 
 ## REST APIs
@@ -236,6 +237,7 @@ docker run -t -i --rm -p 8000:8000 -p 80:80 \
     -e BAMBOO_ZK_PATH=/bamboo \
     -e BIND=":8000"
     -e CONFIG_PATH="config/production.example.json"
+    -e BAMBOO_DOCKER_AUTO_HOST=true
     bamboo
 ````
 

--- a/builder/run.sh
+++ b/builder/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ -n $AUTO_BAMBOO_HOST ]]; then
+if [[ -n $BAMBOO_DOCKER_AUTO_HOST ]]; then
 sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPoint\": \"$HOST:8000\",/" \
     ${CONFIG_PATH:=config/production.example.json}
 fi

--- a/builder/run.sh
+++ b/builder/run.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+if [[ -n $AUTO_BAMBOO_HOST ]]; then
+sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPoint\": \"$HOST\",/" \
+    ${CONFIG_PATH:=config/production.example.json}
+fi
 haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
 /usr/bin/supervisord

--- a/builder/run.sh
+++ b/builder/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ -n $AUTO_BAMBOO_HOST ]]; then
-sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPoint\": \"$HOST\",/" \
+sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPoint\": \"$HOST:8000\",/" \
     ${CONFIG_PATH:=config/production.example.json}
 fi
 haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid


### PR DESCRIPTION
This automatically configures bamboo to set BAMBOO_ENDPOINT to be the value of HOST in the container. if AUTO_BAMBOO_HOST environment variable is set.  This makes it easy to scale Bamboo using Marathon as it will automatically determine the correct Bamboo endpoint based on where the current container is running.
This change is necessary to support this feature since we can't simply set BAMBOO_ENDPOINT=$HOST in Marathon as Marathon doesn't
seem to support parameter substitution for environment variable values.