### PR TITLE
prefix host with http when BAMBOO_DOCKER_AUTO_HOST is set

### DIFF
--- a/builder/run.sh
+++ b/builder/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ -n $BAMBOO_DOCKER_AUTO_HOST ]]; then
-sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPoint\": \"$HOST:8000\",/" \
+sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPoint\": \"http:\/\/$HOST:8000\",/" \
     ${CONFIG_PATH:=config/production.example.json}
 fi
 haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid


### PR DESCRIPTION
@activars Sorry, but i just realized I forgot to prefix $HOST with http://. I just tested and made sure this works.  Sorry about that.
