### PR TITLE
Add support for STATSD_* environment variables

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 )
 
 var logger = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lshortfile)
@@ -52,6 +53,9 @@ func FromFile(filePath string) (Configuration, error) {
 	setValueFromEnv(&conf.HAProxy.TemplatePath, "HAPROXY_TEMPLATE_PATH")
 	setValueFromEnv(&conf.HAProxy.OutputPath, "HAPROXY_OUTPUT_PATH")
 	setValueFromEnv(&conf.HAProxy.ReloadCommand, "HAPROXY_RELOAD_CMD")
+	setValueFromEnv(&conf.StatsD.Host, "STATSD_HOST")
+	setValueFromEnv(&conf.StatsD.Prefix, "STATSD_PREFIX")
+	setBoolValueFromEnv(&conf.StatsD.Enabled, "STATSD_ENABLED")
 	return *conf, err
 }
 
@@ -61,4 +65,18 @@ func setValueFromEnv(field *string, envVar string) {
 		log.Printf("Using environment override %s=%s", envVar, env)
 		*field = env
 	}
+}
+
+func setBoolValueFromEnv(field *bool, envVar string) {
+env := os.Getenv(envVar)
+if len(env) > 0 {
+	log.Printf("Using environment override %s=%t", envVar, env)
+	x, err := strconv.ParseBool(env)
+	if err != nil {
+		log.Printf("Error converting boolean value: %s\n", err)
+	}
+	*field = x
+} else {
+	log.Printf("Environment variable not set: %s", envVar)
+}
 }


### PR DESCRIPTION
I found no existing way to use environment variables to enable and modify the statsd configuration for the bamboo docker container.  This PR adds support for modifying the bamboo docker container statsd configuration via environment variables.  I've tested this on my own mesos cluster and confirmed it's sending metrics to my statsd server that I can view in graphite.
NOTE: This is the first time I've touched GO, so my code may not be the best. It does work though :) 