### PR TITLE
Fix /kardianos/osext dependency location

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3,9 +3,9 @@
 	"GoVersion": "go1.3.3",
 	"Deps": [
 		{
-			"ImportPath": "bitbucket.org/kardianos/osext",
+			"ImportPath": "github.com/kardianos/osext",
 			"Comment": "null-15",
-			"Rev": "44140c5fc69ecf1102c5ef451d73cd98ef59b178"
+			"Rev": "0af7634e455e7ecd558a196743d8a3f700b945c0"
 		},
 		{
 			"ImportPath": "github.com/natefinch/lumberjack",

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	lumberjack "github.com/natefinch/lumberjack"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/zenazn/goji"


### PR DESCRIPTION
/kardianos/osext has moved to github, see https://bitbucket.org/kardianos/osext/commits/816c96ec6fef6a0cd72c9395d192c4bd0d918753