### PR TITLE
Support multiple service ports

### DIFF
--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -77,15 +77,12 @@ backend {{ $app.EscapedId }}-cluster{{ if $app.HealthCheckPath }}
 ## ( see https://mesosphere.github.io/marathon/docs/service-discovery-load-balancing.html#ports-assignment ))
 ## to haproxy frontend port
 ##
-## {{ range $index, $app := .Apps }}
-## listen {{ $app.EscapedId }}_{{ $app.ServicePort }}
-##   bind *:{{ $app.ServicePort }}
-##   mode http
-##   {{ if $app.HealthCheckPath }}
-##   # option httpchk GET {{ $app.HealthCheckPath }}
-##   {{ end }}
-##   balance leastconn
-##   option forwardfor
-##         {{ range $page, $task := .Tasks }}
-##         server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ end }}
-## {{ end }}
+## {{ range $appIndex, $app := .Apps }} {{ range $portIndex, $port := $app.ServicePorts }}
+## listen {{ $app.EscapedId }}-tcp-{{ $port }}
+##         bind *:{{ $port }}
+##         mode tcp
+##         balance roundrobin
+##         option tcplog{{ end }}
+##         {{ range $taskIndex, $task := $app.Tasks }}
+##         server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }}
+## {{ end }} {{ end }}

--- a/services/marathon/marathon.go
+++ b/services/marathon/marathon.go
@@ -176,9 +176,8 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 			Tasks:           simpleTasks,
 			HealthCheckPath: parseHealthCheckPath(marathonApps[appId].HealthChecks),
 			Env:             marathonApps[appId].Env,
+			ServicePorts:    marathonApps[appId].Ports,
 		}
-
-		app.ServicePorts = marathonApps[appId].Ports
 
 		apps = append(apps, app)
 	}

--- a/services/marathon/marathon.go
+++ b/services/marathon/marathon.go
@@ -21,7 +21,7 @@ type App struct {
 	EscapedId       string
 	HealthCheckPath string
 	Tasks           []Task
-	ServicePort     int
+	ServicePorts    []int
 	Env             map[string]string
 }
 
@@ -178,9 +178,7 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 			Env:             marathonApps[appId].Env,
 		}
 
-		if len(marathonApps[appId].Ports) > 0 {
-			app.ServicePort = marathonApps[appId].Ports[0]
-		}
+		app.ServicePorts = marathonApps[appId].Ports
 
 		apps = append(apps, app)
 	}


### PR DESCRIPTION
This adds support for multiple service ports per Marathon app. (Addresses #54)

The updated `ServicePorts` example assumes TCP, but here's an example of how we could conditionally use TCP or HTTP:
_Question: Does `BAMBOO_HTTP_PORT` need to be case to an int before the `eq $port` comparisons?_
```go
# Template Customization
frontend http-in
        bind *:80
        {{ $services := .Services }}
        {{ range $index, $app := .Apps }} {{ range $portIndex, $port := $app.ServicePorts }} {{ if eq $port $app.Env.BAMBOO_HTTP_PORT }} {{ if hasKey $services $app.Id }} {{ $service := getService $services $app.Id }}
        acl {{ $app.EscapedId }}-aclrule {{ $service.Acl}}
        use_backend {{ $app.EscapedId }}-http-{{ $port }} if {{ $app.EscapedId }}-aclrule
        {{ else }}

        # This is the default proxy criteria
        acl {{ $app.EscapedId }}-aclrule path_beg -i {{ $app.Id }}
        use_backend {{ $app.EscapedId }}-http-{{ $port }} if {{ $app.EscapedId }}-aclrule
        {{ end }} {{ end }} {{ end }} {{ end }}

{{ range $appIndex, $app := .Apps }} {{ range $portIndex, $port := $app.ServicePorts }} {{ if eq $port $app.Env.BAMBOO_HTTP_PORT }}
backend {{ $app.EscapedId }}-http-{{ $port }} {{ if $app.HealthCheckPath }}
        option httpchk GET {{ $app.HealthCheckPath }}
        http-check expect rstring .*
        {{ end }}
        balance leastconn
        option httpclose
        option forwardfor{{ else }}
listen {{ $app.EscapedId }}-tcp-{{ $port }}
        bind *:{{ $port }}
        mode tcp
        balance roundrobin
        option tcplog{{ end }}
        {{ range $taskIndex, $task := $app.Tasks }}
        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ end }}
{{ end }} {{ end }}
```

This could be further improved by adding `App.HealthCheckPort` and only setting up the httpchk if the ports match.