### PR TITLE
fixes `godep restore` failure

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3,9 +3,9 @@
 	"GoVersion": "go1.3.3",
 	"Deps": [
 		{
-			"ImportPath": "bitbucket.org/kardianos/osext",
-			"Comment": "null-15",
-			"Rev": "44140c5fc69ecf1102c5ef451d73cd98ef59b178"
+			"ImportPath": "github.com/kardianos/osext",
+			"Comment": "null-18",
+			"Rev": "ccfcd0245381f0c94c68f50626665eed3c6b726a"
 		},
 		{
 			"ImportPath": "github.com/natefinch/lumberjack",

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	lumberjack "github.com/natefinch/lumberjack"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/zenazn/goji"


### PR DESCRIPTION
`godep restore` was failing because @kardianos has moved osext from bitbucket to github. This commit fixes Godeps and bamboo.go to reflect the new name: `github.com/kardianos/osext`