### PR TITLE
Remove http-check HAProxy configuration parameter from template.

### DIFF
--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -63,7 +63,6 @@ listen {{ $app.EscapedId }}-cluster-tcp :{{ $app.Env.BAMBOO_TCP_PORT }}
 {{ end }}
 backend {{ $app.EscapedId }}-cluster{{ if $app.HealthCheckPath }}
         option httpchk GET {{ $app.HealthCheckPath }}
-        http-check expect rstring .*
         {{ end }}
         balance leastconn
         option httpclose


### PR DESCRIPTION
The check causes HTTP error responses with non-empty body content to
lead to a valid check outcome.

This commit partially reverts commit
6791f2606252622194e22724897e2228adfe57c1.

Fixes QubitProducts/bamboo#90.