### PR TITLE
auth implementation

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -45,6 +45,8 @@ func FromFile(filePath string) (Configuration, error) {
 	conf := &Configuration{}
 	err := conf.FromFile(filePath)
 	setValueFromEnv(&conf.Marathon.Endpoint, "MARATHON_ENDPOINT")
+	setValueFromEnv(&conf.Marathon.AuthUsername, "MARATHON_USERNAME")
+	setValueFromEnv(&conf.Marathon.AuthPassword, "MARATHON_PASSWORD")
 
 	setValueFromEnv(&conf.Bamboo.Endpoint, "BAMBOO_ENDPOINT")
 	setValueFromEnv(&conf.Bamboo.Zookeeper.Host, "BAMBOO_ZK_HOST")

--- a/configuration/marathon.go
+++ b/configuration/marathon.go
@@ -10,6 +10,12 @@ import (
 type Marathon struct {
 	// comma separated marathon http endpoints including port number
 	Endpoint string
+
+	// username for HTTP Basic Authentication
+	AuthUsername string
+
+	// password for HTTP Basic Authentication
+	AuthPassword string
 }
 
 func (m Marathon) Endpoints() []string {

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -116,6 +116,9 @@ func registerMarathonEvent(conf *configuration.Configuration) {
 	for _, marathon := range conf.Marathon.Endpoints() {
 		url := marathon + "/v2/eventSubscriptions?callbackUrl=" + conf.Bamboo.Endpoint + "/api/marathon/event_callback"
 		req, _ := http.NewRequest("POST", url, nil)
+		if (len(conf.Marathon.AuthUsername) > 0) {
+			req.SetBasicAuth(conf.Marathon.AuthUsername, conf.Marathon.AuthPassword)
+		}
 		req.Header.Add("Content-Type", "application/json")
 		client.Do(req)
 	}


### PR DESCRIPTION
I added support for Marathon Basic Auth, using two environment variables that can be set:
* MARATHON_USERNAME
* MARATHON_PASSWORD

I haven't extensively tested this yet, but it is important for people (like us) who expose marathon REST API to the world with basic auth.