### PR TITLE
Generate haproxy config file on start

### DIFF
--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -68,6 +68,7 @@ func main() {
 	handlers := event_bus.Handlers{Conf: &conf, Zookeeper: zkConn}
 	eventBus.Register(handlers.MarathonEventHandler)
 	eventBus.Register(handlers.ServiceEventHandler)
+	eventBus.Publish(event_bus.ServiceEvent{EventType: "init"})
 
 	// Start server
 	initServer(&conf, zkConn, eventBus)


### PR DESCRIPTION
Bamboo doesn't seem to generate the HAProxy config on start.
If there is no event, nothing happens and the applications running on Marathon are unreachable.