### PR TITLE
Checkout the 'maintain' branch of lumberjack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,14 @@ ADD builder/run.sh /run.sh
 
 WORKDIR /opt/go/src/github.com/QubitProducts/bamboo
 
+# Checkout the 'maintain' branch of lumberjack
+RUN mkdir -p /opt/go/src/github.com/natefinch && \
+    cd /opt/go/src/github.com/natefinch && \
+    git clone https://github.com/natefinch/lumberjack.git && \
+    cd lumberjack && \
+    git checkout maintain
+
 RUN go get github.com/tools/godep && \
-    go get github.com/natefinch/lumberjack && \
     go get -t github.com/smartystreets/goconvey && \
     /opt/go/bin/godep restore && \
     go build && \


### PR DESCRIPTION
In the 'master' branch of lumberjack, The field 'Filename' of 'Logger' is removed. It will make a mistake when 'go build' Bamboo.