### PR TITLE
Fix reload commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This section tries to explain usage in code comment style:
   "HAProxy": {
     "TemplatePath": "/var/bamboo/haproxy_template.cfg",
     "OutputPath": "/etc/haproxy/haproxy.cfg",
-    "ReloadCommand": "read PIDS < /var/run/haproxy.pid; haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $PIDS && while ps -p $PIDS; do sleep 0.2; done"
+    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)"
   },
   
   // Enable or disable StatsD event tracking

--- a/config/development.json
+++ b/config/development.json
@@ -15,7 +15,7 @@
   "HAProxy": {
     "TemplatePath": "config/haproxy_template.cfg",
     "OutputPath": "/etc/haproxy/haproxy.cfg",
-    "ReloadCommand": "read PIDS < /var/run/haproxy.pid; haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $PIDS && while ps -p $PIDS; do sleep 0.2; done"
+    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)"
   },
 
   "StatsD": {

--- a/config/production.example.json
+++ b/config/production.example.json
@@ -15,7 +15,7 @@
   "HAProxy": {
     "TemplatePath": "config/haproxy_template.cfg",
     "OutputPath": "/etc/haproxy/haproxy.cfg",
-    "ReloadCommand": "PIDS=`pidof haproxy`; haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $PIDS && while ps -p $PIDS; do sleep 0.2; done"
+    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)"
   },
 
   "StatsD": {


### PR DESCRIPTION
The following problems were fixed with the given reload commands:

- Start in daemon mode: The PID file is not written by HAProxy unless
  daemon mode is enabled or the service is managed by systemd. As we
  cannot guarantee the latter, we go with the former.
- Do not use `pidof haproxy`: If the reload occurs while at least two
  HAProxy instances are running (which can happen when a newer instance
  is waiting for an older instance to finish a long-running connection),
  the command will catch both PIDs and pass them to the `-sf` switch of
  a new HAProxy instance. While this does not seem to break things, it
  brings an unnecessary, possibly confusing PID into the game.
- Remove loop waiting for PIDs to finish: This was introduced along
  commit 3bf7fd5864af and should actually not be required since that
  patch makes Bamboo synchronize reload commands already. Moreover, the
  HAProxy code indicates that it does not return before both (a)
  existing HAProxy processes specified via `-sf` [have been signalled to
  stop listening](https://github.com/haproxy/haproxy-1.5/blob/cd06992bf88eaed48502a88d36044e369c70ca31/src/haproxy.c#L1420) and (b) the new process's PID [has been written into
  the PID file](https://github.com/haproxy/haproxy-1.5/blob/cd06992bf88eaed48502a88d36044e369c70ca31/src/haproxy.c#L1575).

**IMPORTANT:** This needs some thorough testing. While a ran several tests via a containerized instance of HAProxy, it is hard to catch all cases without operating in a real environment. I am going to do that starting tomorrow and see how it works out.

/cc @sttts for additional review as he did one of the referenced commits.

#refs #79