### PR TITLE
haproxy.go's GetTemplateData now properly propogates errors upwards.  ev...

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -16,6 +16,7 @@ type StateAPI struct {
 }
 
 func (state *StateAPI) Get(w http.ResponseWriter, r *http.Request) {
-	payload, _ := json.Marshal(haproxy.GetTemplateData(state.Config, state.Zookeeper))
+        templateData, _ := haproxy.GetTemplateData(state.Config, state.Zookeeper)
+	payload, _ := json.Marshal(templateData)
 	io.WriteString(w, string(payload))
 }

--- a/services/event_bus/event_handler.go
+++ b/services/event_bus/event_handler.go
@@ -79,7 +79,12 @@ func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) bool {
 		log.Panicf("Cannot read template file: %s", err)
 	}
 
-	templateData := haproxy.GetTemplateData(conf, conn)
+	templateData, err := haproxy.GetTemplateData(conf, conn)
+	
+	if err != nil {
+	  log.Printf("Not updating haproxy because we failed to retrieve template data: \n %s\n", err)
+	  return false
+	}
 
 	newContent, err := template.RenderTemplate(conf.HAProxy.TemplatePath, string(templateContent), templateData)
 

--- a/services/haproxy/haproxy.go
+++ b/services/haproxy/haproxy.go
@@ -12,10 +12,19 @@ type templateData struct {
 	Services map[string]service.Service
 }
 
-func GetTemplateData(config *conf.Configuration, conn *zk.Conn) interface{} {
+func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (interface{}, error) {
 
-	apps, _ := marathon.FetchApps(config.Marathon)
-	services, _ := service.All(conn, config.Bamboo.Zookeeper)
+	apps, err := marathon.FetchApps(config.Marathon)
 
-	return templateData{apps, services}
+	if err != nil {
+	   return nil, err
+ 	}
+
+	services, err := service.All(conn, config.Bamboo.Zookeeper)
+
+	if err != nil {
+	   return nil, err
+ 	}
+
+	return templateData{apps, services}, nil
 }


### PR DESCRIPTION
...ent_handler.go now refuses to update the haproxy config if GetTemplateData returns errors