### PR TITLE
Additional marathon data for template generation

### DIFF
--- a/services/marathon/marathon.go
+++ b/services/marathon/marathon.go
@@ -13,6 +13,7 @@ import (
 type Task struct {
 	Host string
 	Port int
+	Alive bool
 }
 
 // An app may have multiple processes
@@ -23,6 +24,8 @@ type App struct {
 	Tasks           []Task
 	ServicePort     int
 	Env             map[string]string
+	Labels          map[string]string
+	SplitId         []string
 }
 
 type AppList []App
@@ -45,6 +48,10 @@ type MarathonTasks struct {
 	Tasks MarathonTaskList `json:tasks`
 }
 
+type HealthCheckResult struct {
+	Alive bool
+}
+
 type MarathonTask struct {
 	AppId        string
 	Id           string
@@ -54,6 +61,7 @@ type MarathonTask struct {
 	StartedAt    string
 	StagedAt     string
 	Version      string
+	HealthCheckResults []HealthCheckResult
 }
 
 func (slice MarathonTaskList) Len() int {
@@ -77,6 +85,7 @@ type MarathonApp struct {
 	HealthChecks []HealthChecks    `json:healthChecks`
 	Ports        []int             `json:ports`
 	Env          map[string]string `json:env`
+	Labels       map[string]string `json:labels`
 }
 
 type HealthChecks struct {
@@ -149,6 +158,19 @@ func fetchTasks(endpoint string) (map[string][]MarathonTask, error) {
 	}
 }
 
+func calculateTaskHealth(healthCheckResults []HealthCheckResult, healthChecks []HealthChecks) bool {
+	//If we don't even have health check results for every health check, don't count the task as healthy
+	if len(healthChecks) > len(healthCheckResults) {
+		return false;
+	}
+	for _, healthCheck := range healthCheckResults {
+		if !healthCheck.Alive {
+			return false;
+		}
+	}
+	return true;
+}
+
 func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]MarathonApp) AppList {
 
 	apps := AppList{}
@@ -158,7 +180,7 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 
 		for _, task := range tasks {
 			if len(task.Ports) > 0 {
-				simpleTasks = append(simpleTasks, Task{Host: task.Host, Port: task.Ports[0]})
+				simpleTasks = append(simpleTasks, Task{Host: task.Host, Port: task.Ports[0], Alive: calculateTaskHealth(task.HealthCheckResults, marathonApps[appId].HealthChecks)})
 			}
 		}
 
@@ -176,6 +198,8 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 			Tasks:           simpleTasks,
 			HealthCheckPath: parseHealthCheckPath(marathonApps[appId].HealthChecks),
 			Env:             marathonApps[appId].Env,
+			Labels:          marathonApps[appId].Labels,
+			SplitId:         strings.Split(appId, "/"),
 		}
 
 		if len(marathonApps[appId].Ports) > 0 {


### PR DESCRIPTION
Just offering this up because we've found this data useful for generating our haproxy config files and thought it might be useful to others.  This adds three pieces of data available in the templates:

Task.Alive:  This lets the template avoid putting a service into rotation until it passes marathon's health checks.  While we have haproxy also performing health checks, we were still getting errors on application deployment because haproxy assumes servers are health by default and won't pull them out of rotation until they fail health checks

App.Labels: Marathon's labels for the app

App.SplitId: App.Id or EscapedId are the entire application name including application groups.  We're doing some stuff based on the application groups in our haproxy template, so we wanted to be able to access the parts of the path rather than the entire app id.  (I.e. if you had an app in marathon called '/foo/bar', App.Id would be '/foo/bar' while App.SplitId would be ['foo', 'bar'])