### PR TITLE
Prevent TCP (and COMMAND) health checks from setting HealthCheckPath

### DIFF
--- a/services/marathon/marathon.go
+++ b/services/marathon/marathon.go
@@ -76,13 +76,14 @@ type MarathonApps struct {
 
 type MarathonApp struct {
 	Id           string            `json:id`
-	HealthChecks []HealthChecks    `json:healthChecks`
+	HealthChecks []HealthCheck    `json:healthChecks`
 	Ports        []int             `json:ports`
 	Env          map[string]string `json:env`
 }
 
-type HealthChecks struct {
+type HealthCheck struct {
 	Path string `json:path`
+	Protocol string `json:protocol`
 }
 
 func fetchMarathonApps(endpoint string) (map[string]MarathonApp, error) {
@@ -190,9 +191,12 @@ func createApps(tasksById map[string][]MarathonTask, marathonApps map[string]Mar
 	return apps
 }
 
-func parseHealthCheckPath(checks []HealthChecks) string {
-	if len(checks) > 0 {
-		return checks[0].Path
+func parseHealthCheckPath(checks []HealthCheck) string {
+	for _, check := range checks {
+		if check.Protocol != "HTTP" {
+			continue
+		}
+		return check.Path
 	}
 	return ""
 }

--- a/services/marathon/marathon_test.go
+++ b/services/marathon/marathon_test.go
@@ -1,0 +1,45 @@
+package marathon
+
+import (
+	. "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestParseHealthCheckPathTCP(t *testing.T) {
+	Convey("#parseHealthCheckPath", t, func() {
+		checks := []HealthCheck{
+			HealthCheck{"/", "TCP"},
+			HealthCheck{"/foobar", "TCP"},
+			HealthCheck{"", "TCP"},
+		}
+		Convey("should return no path if all checks are TCP", func() {
+			So(parseHealthCheckPath(checks), ShouldEqual, "")
+		})
+	})
+}
+
+func TestParseHealthCheckPathHTTP(t *testing.T) {
+	Convey("#parseHealthCheckPath", t, func() {
+		checks := []HealthCheck{
+			HealthCheck{"/first", "HTTP"},
+			HealthCheck{"/", "HTTP"},
+			HealthCheck{"", "HTTP"},
+		}
+		Convey("should return the first path if all checks are HTTP", func() {
+			So(parseHealthCheckPath(checks), ShouldEqual, "/first")
+		})
+	})
+}
+
+func TestParseHealthCheckPathMixed(t *testing.T) {
+	Convey("#parseHealthCheckPath", t, func() {
+		checks := []HealthCheck{
+			HealthCheck{"", "TCP"},
+			HealthCheck{"/path", "HTTP"},
+			HealthCheck{"/", "HTTP"},
+		}
+		Convey("should return the first path if some checks are HTTP", func() {
+			So(parseHealthCheckPath(checks), ShouldEqual, "/path")
+		})
+	})
+}


### PR DESCRIPTION
Simple check to parse the protocol from marathon and prevent the path being set erroneously. TODO: Pass tcp health check information on to template