### PR TITLE
add optional HTTP basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Configuration in the `production.json` file can be overridden with environment v
 Environment Variable | Corresponds To
 ---------------------|---------------
 `MARATHON_ENDPOINT` | Marathon.Endpoint
+`MARATHON_USER` | Marathon.User
+`MARATHON_PASSWORD` | Marathon.Password
 `BAMBOO_ENDPOINT` | Bamboo.Endpoint
 `BAMBOO_ZK_HOST` | Bamboo.Zookeeper.Host
 `BAMBOO_ZK_PATH` | Bamboo.Zookeeper.Path

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -45,6 +45,8 @@ func FromFile(filePath string) (Configuration, error) {
 	conf := &Configuration{}
 	err := conf.FromFile(filePath)
 	setValueFromEnv(&conf.Marathon.Endpoint, "MARATHON_ENDPOINT")
+	setValueFromEnv(&conf.Marathon.User, "MARATHON_USER")
+	setValueFromEnv(&conf.Marathon.Password, "MARATHON_PASSWORD")
 
 	setValueFromEnv(&conf.Bamboo.Endpoint, "BAMBOO_ENDPOINT")
 	setValueFromEnv(&conf.Bamboo.Zookeeper.Host, "BAMBOO_ZK_HOST")

--- a/configuration/marathon.go
+++ b/configuration/marathon.go
@@ -10,6 +10,8 @@ import (
 type Marathon struct {
 	// comma separated marathon http endpoints including port number
 	Endpoint string
+	User string
+	Password string
 }
 
 func (m Marathon) Endpoints() []string {

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -126,6 +126,9 @@ func registerMarathonEvent(conf *configuration.Configuration) {
 		url := marathon + "/v2/eventSubscriptions?callbackUrl=" + conf.Bamboo.Endpoint + "/api/marathon/event_callback"
 		req, _ := http.NewRequest("POST", url, nil)
 		req.Header.Add("Content-Type", "application/json")
+		if (len(conf.Marathon.User)>0 && len(conf.Marathon.Password)>0) {
+			req.SetBasicAuth(conf.Marathon.User, conf.Marathon.Password)
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			errorMsg := "An error occurred while accessing Marathon callback system: %s\n"


### PR DESCRIPTION
If your Marathon endpoint is authenticated, Bamboo needs to pass Username/Password.
This simple implementation uses the built-in Go net/http SetBasicAuth() if both the user & password are specified.