### PR TITLE
Shell variable bugs in supervisord.conf

### DIFF
--- a/builder/supervisord.conf
+++ b/builder/supervisord.conf
@@ -4,5 +4,5 @@ loglevel=debug
 
 [program:bamboo]
 redirect_stderr=true
-command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; /var/bamboo/bamboo -bind="${BIND-:8000}" -config=${CONFIG_PATH-:config/production.example.json}"
+command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"
 

--- a/builder/supervisord.conf.prod
+++ b/builder/supervisord.conf.prod
@@ -2,5 +2,5 @@
 nodaemon=true
 
 [program:bamboo]
-command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; /var/bamboo/bamboo -bind="${BIND-:8000}" -config=${CONFIG_PATH-:config/production.example.json}"
+command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"
 


### PR DESCRIPTION
The supervisord.conf files had an incorrect colon in the default for the variable expansion of `$CONFIG_PATH`. This was most likely due to the adjacent variable `$BIND` having a default that starts with a colon (:8000). It's also confusing because it looks similar to the alternate ${var:-val} syntax for expanding a variable with a default.

To reduce confusion in the future I changed both variables to use the ${var:-val} syntax which is slightly more robust in this case (it uses the default when the variables is defined as an empty string).