### PR TITLE
re #149 support event streaming

### DIFF
--- a/api/event_subscription.go
+++ b/api/event_subscription.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/QubitProducts/bamboo/configuration"
-	eb "github.com/QubitProducts/bamboo/services/event_bus"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/QubitProducts/bamboo/configuration"
+	eb "github.com/QubitProducts/bamboo/services/event_bus"
 )
 
 type EventSubscriptionAPI struct {
@@ -16,9 +17,16 @@ type EventSubscriptionAPI struct {
 }
 
 func (sub *EventSubscriptionAPI) Callback(w http.ResponseWriter, r *http.Request) {
-	var event eb.MarathonEvent
-
 	payload, _ := ioutil.ReadAll(r.Body)
+
+	sub.Notify(payload)
+
+	io.WriteString(w, "Got it!")
+}
+
+func (sub *EventSubscriptionAPI) Notify(payload []byte) {
+
+	var event eb.MarathonEvent
 	err := json.Unmarshal(payload, &event)
 
 	if err != nil {
@@ -26,5 +34,4 @@ func (sub *EventSubscriptionAPI) Callback(w http.ResponseWriter, r *http.Request
 	}
 
 	sub.EventBus.Publish(event)
-	io.WriteString(w, "Got it!")
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -47,6 +47,7 @@ func FromFile(filePath string) (Configuration, error) {
 	setValueFromEnv(&conf.Marathon.Endpoint, "MARATHON_ENDPOINT")
 	setValueFromEnv(&conf.Marathon.User, "MARATHON_USER")
 	setValueFromEnv(&conf.Marathon.Password, "MARATHON_PASSWORD")
+	setBoolValueFromEnv(&conf.Marathon.UseEventStream, "MARATHON_USE_EVENT_STREAM")
 
 	setValueFromEnv(&conf.Bamboo.Endpoint, "BAMBOO_ENDPOINT")
 	setValueFromEnv(&conf.Bamboo.Zookeeper.Host, "BAMBOO_ZK_HOST")

--- a/configuration/marathon.go
+++ b/configuration/marathon.go
@@ -12,6 +12,8 @@ type Marathon struct {
 	Endpoint string
 	User     string
 	Password string
+
+	UseEventStream bool
 }
 
 func (m Marathon) Endpoints() []string {

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -186,9 +186,10 @@ func listenToMarathonEventStream(conf *configuration.Configuration, sub api.Even
 
 	for _, marathon := range conf.Marathon.Endpoints() {
 		ticker := time.NewTicker(1 * time.Second)
+		eventsURL := marathon + "/v2/events"
 		go func() {
 			for _ = range ticker.C {
-				req, err := http.NewRequest("GET", marathon+"/v2/events", nil)
+				req, err := http.NewRequest("GET", eventsURL, nil)
 				req.Header.Set("Accept", "text/event-stream")
 				if err != nil {
 					errorMsg := "An error occurred while creating request to Marathon events system: %s\n"

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -191,6 +191,9 @@ func listenToMarathonEventStream(conf *configuration.Configuration, sub api.Even
 			for _ = range ticker.C {
 				req, err := http.NewRequest("GET", eventsURL, nil)
 				req.Header.Set("Accept", "text/event-stream")
+				if len(conf.Marathon.User) > 0 && len(conf.Marathon.Password) > 0 {
+					req.SetBasicAuth(conf.Marathon.User, conf.Marathon.Password)
+				}
 				if err != nil {
 					errorMsg := "An error occurred while creating request to Marathon events system: %s\n"
 					log.Printf(errorMsg, err)

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -188,8 +188,9 @@ func listenToEventStream(conf configuration.Configuration, eventBus *event_bus.E
 	client.Timeout = 0 * time.Second
 
 	for _, marathon := range conf.Marathon.Endpoints() {
+		ticker := time.NewTicker(1 * time.Second)
 		go func() {
-			for {
+			for _ = range ticker.C {
 				req, err := http.NewRequest("GET", marathon+"/v2/events", nil)
 				req.Header.Set("Accept", "text/event-stream")
 				if err != nil {
@@ -200,6 +201,8 @@ func listenToEventStream(conf configuration.Configuration, eventBus *event_bus.E
 
 				resp, err := client.Do(req)
 				if err != nil {
+					errorMsg := "An error occurred while making a request to Marathon events system: %s\n"
+					log.Printf(errorMsg, err)
 					continue
 				}
 

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -108,7 +108,7 @@ func initServer(conf *configuration.Configuration, conn *zk.Conn, eventBus *even
 
 	if conf.Marathon.UseEventStream {
 		// Listen events stream from Marathon
-		listenToEventStream(conf, eventSubAPI)
+		listenToMarathonEventStream(conf, eventSubAPI)
 	} else {
 		registerMarathonEvent(conf)
 	}
@@ -180,7 +180,7 @@ func listenToZookeeper(conf configuration.Configuration, eventBus *event_bus.Eve
 	return serviceConn
 }
 
-func listenToEventStream(conf *configuration.Configuration, sub api.EventSubscriptionAPI) {
+func listenToMarathonEventStream(conf *configuration.Configuration, sub api.EventSubscriptionAPI) {
 	client := &http.Client{}
 	client.Timeout = 0 * time.Second
 

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -203,6 +203,8 @@ func listenToEventStream(conf configuration.Configuration, eventBus *event_bus.E
 					continue
 				}
 
+				defer resp.Body.Close()
+
 				reader := bufio.NewReader(resp.Body)
 				for {
 					line, err := reader.ReadString('\n')
@@ -238,7 +240,7 @@ func listenToEventStream(conf configuration.Configuration, eventBus *event_bus.E
 					eventBus.Publish(event)
 				}
 
-				_ = resp.Body.Close()
+				log.Println("Event stream connection was closed. Re-opening...")
 			}
 		}()
 	}


### PR DESCRIPTION
I'm happy to contribute this small, but very helpful improvement - event stream listener.

Starting from Marathon 0.9.0 it provides /v2/events endpoint, which is implementation of Server-sent Events. It's much better compared to event callbacks since there is no need to register Bamboo as callback on Marathon. 

Implementation is backward compatible with 0.7.0 because this mode is disabled by default. It could be enabled in config like that:
```js
{
  "Marathon": {
    "Endpoint": "...",
    "UseEventStream": true
  }
}
```

NB: if "UseEventStream" is enabled then callbacks are not auto-registered. 

When Bamboo will drop support for Marathon < 0.9.0 then this property could be `true` by default.


Implementation was tested with Marathon 0.9.0, covered cases:
1. Listening for events
2. Re-connection when Marathon is not responding
3. Bad data from Marathon
4. Many events at a time