### PR TITLE
Support graceful shutdown of haproxy

### DIFF
--- a/builder/run.sh
+++ b/builder/run.sh
@@ -4,4 +4,4 @@ sed -i "s/^.*Endpoint\": \"\(http:\/\/haproxy-ip-address:8000\)\".*$/    \"EndPo
     ${CONFIG_PATH:=config/production.example.json}
 fi
 haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
-/usr/bin/supervisord
+exec /usr/bin/supervisord

--- a/builder/supervisord.conf
+++ b/builder/supervisord.conf
@@ -4,5 +4,4 @@ loglevel=debug
 
 [program:bamboo]
 redirect_stderr=true
-command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"
-
+command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; exec /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"

--- a/builder/supervisord.conf
+++ b/builder/supervisord.conf
@@ -5,3 +5,4 @@ loglevel=debug
 [program:bamboo]
 redirect_stderr=true
 command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; exec /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"
+stopwaitsecs=60

--- a/builder/supervisord.conf.prod
+++ b/builder/supervisord.conf.prod
@@ -3,3 +3,4 @@ nodaemon=true
 
 [program:bamboo]
 command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; exec /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"
+stopwaitsecs=60

--- a/builder/supervisord.conf.prod
+++ b/builder/supervisord.conf.prod
@@ -2,5 +2,4 @@
 nodaemon=true
 
 [program:bamboo]
-command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"
-
+command=/bin/bash -c "MARATHON_ENDPOINT=${MARATHON_ENDPOINT}; BAMBOO_ENDPOINT=${BAMBOO_ENDPOINT}; BAMBOO_ZK_HOST=${BAMBOO_ZK_HOST}; BAMBOO_ZK_PATH=${BAMBOO_ZK_PATH}; exec /var/bamboo/bamboo -bind="${BIND:-:8000}" -config=${CONFIG_PATH:-config/production.example.json}"

--- a/config/development.json
+++ b/config/development.json
@@ -15,7 +15,9 @@
   "HAProxy": {
     "TemplatePath": "config/haproxy_template.cfg",
     "OutputPath": "/etc/haproxy/haproxy.cfg",
-    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)"
+    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)",
+    "ShutdownCommand": "PID=$(cat /var/run/haproxy.pid); kill -USR1 $PID; while kill -0 $PID; do sleep 0.1; done",
+    "GraceSeconds": 5
   },
 
   "StatsD": {

--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -36,20 +36,11 @@ defaults
         errorfile 504 /etc/haproxy/errors/504.http
 
 
-frontend graceful_stop_check
-  bind *:2001
-  # Close port immediately on a SIGUSR1.
-  grace 0s
-
-backend graceful_stop_detector
-  description See if we are shutting down gracefully
-  server healthcheck-frontend *:2001 check inter 1s fall 1
-
 frontend health
     bind *:2000
 
     # This returns 503 once we receive USR1 signal
-    acl shutting_down nbsrv(graceful_stop_detector) eq 0
+    acl shutting_down stopping
     monitor-uri /health
     monitor fail if shutting_down
 

--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -25,6 +25,8 @@ defaults
         timeout client  50000
         timeout server  50000
 
+        grace {{ .GraceSeconds }}s
+
         errorfile 400 /etc/haproxy/errors/400.http
         errorfile 403 /etc/haproxy/errors/403.http
         errorfile 408 /etc/haproxy/errors/408.http
@@ -32,6 +34,24 @@ defaults
         errorfile 502 /etc/haproxy/errors/502.http
         errorfile 503 /etc/haproxy/errors/503.http
         errorfile 504 /etc/haproxy/errors/504.http
+
+
+frontend graceful_stop_check
+  bind *:2001
+  # Close port immediately on a SIGUSR1.
+  grace 0s
+
+backend graceful_stop_detector
+  description See if we are shutting down gracefully
+  server healthcheck-frontend *:2001 check inter 1s fall 1
+
+frontend health
+    bind *:2000
+
+    # This returns 503 once we receive USR1 signal
+    acl shutting_down nbsrv(graceful_stop_detector) eq 0
+    monitor-uri /health
+    monitor fail if shutting_down
 
 
 # Template Customization

--- a/config/production.example.json
+++ b/config/production.example.json
@@ -15,7 +15,9 @@
   "HAProxy": {
     "TemplatePath": "config/haproxy_template.cfg",
     "OutputPath": "/etc/haproxy/haproxy.cfg",
-    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)"
+    "ReloadCommand": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)",
+    "ShutdownCommand": "PID=$(cat /var/run/haproxy.pid); kill -USR1 $PID; while kill -0 $PID; do sleep 0.1; done",
+    "GraceSeconds": 5
   },
 
   "StatsD": {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -55,6 +55,8 @@ func FromFile(filePath string) (Configuration, error) {
 	setValueFromEnv(&conf.HAProxy.TemplatePath, "HAPROXY_TEMPLATE_PATH")
 	setValueFromEnv(&conf.HAProxy.OutputPath, "HAPROXY_OUTPUT_PATH")
 	setValueFromEnv(&conf.HAProxy.ReloadCommand, "HAPROXY_RELOAD_CMD")
+	setValueFromEnv(&conf.HAProxy.ShutdownCommand, "HAPROXY_SHUTDOWN_CMD")
+	setIntValueFromEnv(&conf.HAProxy.GraceSeconds, "HAPROXY_GRACE_SECONDS")
 	setValueFromEnv(&conf.StatsD.Host, "STATSD_HOST")
 	setValueFromEnv(&conf.StatsD.Prefix, "STATSD_PREFIX")
 	setBoolValueFromEnv(&conf.StatsD.Enabled, "STATSD_ENABLED")
@@ -68,6 +70,21 @@ func setValueFromEnv(field *string, envVar string) {
 		*field = env
 	}
 }
+
+func setIntValueFromEnv(field *int, envVar string) {
+	env := os.Getenv(envVar)
+	if len(env) > 0 {
+		log.Printf("Using environment override %s=%t", envVar, env)
+		x, err := strconv.Atoi(env)
+		if err != nil {
+			log.Printf("Error converting int value: %s\n", err)
+		}
+		*field = x
+	} else {
+		log.Printf("Environment variable not set: %s", envVar)
+	}
+}
+
 
 func setBoolValueFromEnv(field *bool, envVar string) {
 	env := os.Getenv(envVar)

--- a/configuration/haproxy.go
+++ b/configuration/haproxy.go
@@ -1,7 +1,9 @@
 package configuration
 
 type HAProxy struct {
-	TemplatePath  string
-	OutputPath    string
-	ReloadCommand string
+	TemplatePath    string
+	OutputPath      string
+	ReloadCommand   string
+	ShutdownCommand string
+	GraceSeconds int
 }

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -74,7 +74,7 @@ func main() {
 	eventBus.Publish(event_bus.MarathonEvent{EventType: "bamboo_startup", Timestamp: time.Now().Format(time.RFC3339)})
 
 	// Handle gracefully exit
-	registerOSSignals()
+	registerOSSignals(&conf)
 
 	// Start server
 	initServer(&conf, zkConn, eventBus)
@@ -187,12 +187,23 @@ func configureLog() {
 	}
 }
 
-func registerOSSignals() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+func registerOSSignals(conf *configuration.Configuration) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
 	go func() {
-		for _ = range c {
-			log.Println("Server Stopped")
+		sig := <-sigs
+		if sig == os.Interrupt {
+			log.Println("Server stopping now")
+			os.Exit(0)
+		} else if sig == syscall.SIGTERM {
+			log.Println("Server gracefully exiting...")
+			err := event_bus.ExecCommand(conf.HAProxy.ShutdownCommand)
+			if err != nil {
+				log.Fatalf("HAProxy: graceful shutdown failed\n")
+			} else {
+				log.Println("HAProxy: graceful shutdown complete")
+			}
+			log.Println("Server stopping after graceful haproxy shutdown")
 			os.Exit(0)
 		}
 	}()

--- a/services/event_bus/event_handler.go
+++ b/services/event_bus/event_handler.go
@@ -98,7 +98,7 @@ func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) bool {
 			log.Fatalf("Failed to write template on path: %s", err)
 		}
 
-		err = execCommand(conf.HAProxy.ReloadCommand)
+		err = ExecCommand(conf.HAProxy.ReloadCommand)
 		if err != nil {
 			log.Fatalf("HAProxy: update failed\n")
 		} else {
@@ -112,7 +112,7 @@ func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) bool {
 	}
 }
 
-func execCommand(cmd string) error {
+func ExecCommand(cmd string) error {
 	log.Printf("Exec cmd: %s \n", cmd)
 	output, err := exec.Command("sh", "-c", cmd).CombinedOutput()
 	if err != nil {

--- a/services/haproxy/haproxy.go
+++ b/services/haproxy/haproxy.go
@@ -10,6 +10,7 @@ import (
 type templateData struct {
 	Apps     marathon.AppList
 	Services map[string]service.Service
+	GraceSeconds int
 }
 
 func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (interface{}, error) {
@@ -26,5 +27,7 @@ func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (interface{}, er
 		return nil, err
 	}
 
-	return templateData{apps, services}, nil
+	graceSeconds := config.HAProxy.GraceSeconds
+
+	return templateData{apps, services, graceSeconds}, nil
 }


### PR DESCRIPTION
The purpose of this feature is to allow bamboo to shutdown haproxy gracefully in response to a SIGTERM. In my particular use case we have bamboo running in docker behind an aws ELB. The goal is to generate a health check that can remove bamboo from the ELB before bamboo actually exits, so that we can redeploy bamboo without any requests being lost. My particular way of shutting down bamboo is to run `docker stop` on the container. By default this gives a SIGTERM followed by a SIGKILL 10 seconds later, so a value of GraceSeconds < 10s is reasonable, but the value should be large enought for an upstream balancer to detect that bamboo is unhealthy.  Some changes to the dockerization were necessary so that bamboo would actually get the signal-- child processes of bash or sh need to be run with 'exec'.

I've been testing this by running the container, then running something like:

    while true; do curl --connect-timeout 2 --max-time 2 localhost:2000/health  -sL -w "%{http_code} %{time_total}  " -o /dev/null; echo $(($(date +%s%N)/1000000)); sleep 0.2; done

And then running `docker stop $(docker ps | grep bamboo | awk '{print $1}')` the http status should change from 200 to 503 for 5 seconds.

I'm not sure if people would want this on by default, but GraceSeconds is configurable and setting to 0 allows immediate exit. Also, port 2000  is used for health checking. This could be problematic if not running in docker, so maybe my changes to the haproxy_template should be commented out by default.
