### PR TITLE
Use templateData instead of empty interface

### DIFF
--- a/services/haproxy/haproxy.go
+++ b/services/haproxy/haproxy.go
@@ -12,7 +12,7 @@ type templateData struct {
 	Services map[string]service.Service
 }
 
-func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (interface{}, error) {
+func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (*templateData, error) {
 
 	apps, err := marathon.FetchApps(config.Marathon, config)
 
@@ -26,5 +26,5 @@ func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (interface{}, er
 		return nil, err
 	}
 
-	return templateData{apps, services}, nil
+	return &templateData{apps, services}, nil
 }


### PR DESCRIPTION
Hi everyone,

I'd like to discuss if it would be better to use templateData instead of an interface, cause it's already given.

As far as I can see there should be no reason not to use it.

The function itself is used by eventhandler and api state.

What do you think guys?