### PR TITLE
Clarify Bamboo.Endpoint's uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ This section tries to explain usage in code comment style:
   },
 
   "Bamboo": {
-
     // Bamboo's HTTP address can be accessed by Marathon
-    // This is used for Marathon HTTP callback; must be reachable by Marathon
-    "Host": "http://localhost:8000",
+    // This is used for Marathon HTTP callback, and each instance of Bamboo
+    // must be provided a unique Endpoint directly addressable by Marathon
+    // (e.g., the IP address of each server)
+    "Endpoint": "http://localhost:8000",
 
     // Proxy setting information is stored in Zookeeper
     // Bamboo will create this path if it does not already exist


### PR DESCRIPTION
This makes explicit that each Bamboo instance needs a unique Endpoint address.

We figured this out the hard way after setting the endpoint to a DNS name that round-robined all of the bamboo servers. Only one instance would ever receive an update from Marathon, and so the bamboo instances all end up out-of-sync.

Happy to swap in any other/better language-- but hopefully this will save folks from making the mistake we did.