### PR TITLE
[WIP] Arbitrary config values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: go
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - zookeeperd
+
 go:
   - 1.4
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ cd $GOPATH/src/github.com/QubitProducts/bamboo
 # Build your binary
 go build
 
-# Run test
+# Run test (requires a local zookeeper running)
 goconvey
 ```
 

--- a/api/service.go
+++ b/api/service.go
@@ -12,8 +12,8 @@ import (
 )
 
 type ServiceAPI struct {
-	Config    *conf.Configuration
-	Storage   service.Storage
+	Config  *conf.Configuration
+	Storage service.Storage
 }
 
 func (d *ServiceAPI) All(w http.ResponseWriter, r *http.Request) {

--- a/api/service.go
+++ b/api/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/go-martini/martini"
 	conf "github.com/QubitProducts/bamboo/configuration"
@@ -83,6 +84,9 @@ func extractService(r *http.Request) (service.Service, error) {
 	err := json.Unmarshal(payload, &serviceModel)
 	if err != nil {
 		return serviceModel, errors.New("Unable to decode JSON request")
+	}
+	if !strings.HasPrefix(serviceModel.Id, "/") {
+		serviceModel.Id = "/" + serviceModel.Id
 	}
 
 	return serviceModel, nil

--- a/api/service.go
+++ b/api/service.go
@@ -7,66 +7,67 @@ import (
 	"net/http"
 
 	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/go-martini/martini"
-	zk "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
 	conf "github.com/QubitProducts/bamboo/configuration"
 	"github.com/QubitProducts/bamboo/services/service"
 )
 
 type ServiceAPI struct {
 	Config    *conf.Configuration
-	Zookeeper *zk.Conn
+	Storage   service.Storage
 }
 
 func (d *ServiceAPI) All(w http.ResponseWriter, r *http.Request) {
-	services, err := service.All(d.Zookeeper, d.Config.Bamboo.Zookeeper)
+	services, err := d.Storage.All()
 
 	if err != nil {
 		responseError(w, err.Error())
 		return
 	}
 
-	responseJSON(w, services)
+	byId := make(map[string]service.Service, len(services))
+	for _, s := range services {
+		byId[s.Id] = s
+	}
+
+	responseJSON(w, byId)
 }
 
 func (d *ServiceAPI) Create(w http.ResponseWriter, r *http.Request) {
-	serviceModel, err := extractServiceModel(r)
+	service, err := extractService(r)
 
 	if err != nil {
 		responseError(w, err.Error())
 		return
 	}
 
-	_, err = service.Create(d.Zookeeper, d.Config.Bamboo.Zookeeper, serviceModel.Id, serviceModel.Acl)
+	err = d.Storage.Upsert(service)
 	if err != nil {
 		responseError(w, err.Error())
 		return
 	}
 
-	responseJSON(w, serviceModel)
+	responseJSON(w, service)
 }
 
 func (d *ServiceAPI) Put(params martini.Params, w http.ResponseWriter, r *http.Request) {
-
-	identity := params["_1"]
-	println(identity)
-
-	serviceModel, err := extractServiceModel(r)
+	service, err := extractService(r)
 	if err != nil {
 		responseError(w, err.Error())
 		return
 	}
 
-	_, err = service.Put(d.Zookeeper, d.Config.Bamboo.Zookeeper, identity, serviceModel.Acl)
+	err = d.Storage.Upsert(service)
 	if err != nil {
 		responseError(w, err.Error())
 		return
 	}
 
-	responseJSON(w, serviceModel)
+	responseJSON(w, service)
 }
 
 func (d *ServiceAPI) Delete(params martini.Params, w http.ResponseWriter, r *http.Request) {
-	err := service.Delete(d.Zookeeper, d.Config.Bamboo.Zookeeper, params["_1"])
+	serviceId := params["_1"]
+	err := d.Storage.Delete(serviceId)
 	if err != nil {
 		responseError(w, err.Error())
 		return
@@ -75,7 +76,7 @@ func (d *ServiceAPI) Delete(params martini.Params, w http.ResponseWriter, r *htt
 	responseJSON(w, new(map[string]string))
 }
 
-func extractServiceModel(r *http.Request) (service.Service, error) {
+func extractService(r *http.Request) (service.Service, error) {
 	var serviceModel service.Service
 	payload, _ := ioutil.ReadAll(r.Body)
 

--- a/api/state.go
+++ b/api/state.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 
 	"github.com/QubitProducts/bamboo/configuration"
-	"github.com/QubitProducts/bamboo/services/service"
 	"github.com/QubitProducts/bamboo/services/haproxy"
+	"github.com/QubitProducts/bamboo/services/service"
 )
 
 type StateAPI struct {
-	Config    *configuration.Configuration
-	Storage   service.Storage
+	Config  *configuration.Configuration
+	Storage service.Storage
 }
 
 func (state *StateAPI) Get(w http.ResponseWriter, r *http.Request) {

--- a/api/state.go
+++ b/api/state.go
@@ -5,18 +5,18 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
 	"github.com/QubitProducts/bamboo/configuration"
+	"github.com/QubitProducts/bamboo/services/service"
 	"github.com/QubitProducts/bamboo/services/haproxy"
 )
 
 type StateAPI struct {
 	Config    *configuration.Configuration
-	Zookeeper *zk.Conn
+	Storage   service.Storage
 }
 
 func (state *StateAPI) Get(w http.ResponseWriter, r *http.Request) {
-	templateData, _ := haproxy.GetTemplateData(state.Config, state.Zookeeper)
+	templateData, _ := haproxy.GetTemplateData(state.Config, state.Storage)
 	payload, _ := json.Marshal(templateData)
 	io.WriteString(w, string(payload))
 }

--- a/services/event_bus/event_handler.go
+++ b/services/event_bus/event_handler.go
@@ -3,8 +3,8 @@ package event_bus
 import (
 	"github.com/QubitProducts/bamboo/configuration"
 	"github.com/QubitProducts/bamboo/services/haproxy"
-	"github.com/QubitProducts/bamboo/services/template"
 	"github.com/QubitProducts/bamboo/services/service"
+	"github.com/QubitProducts/bamboo/services/template"
 	"io/ioutil"
 	"log"
 	"os"
@@ -29,8 +29,8 @@ type ServiceEvent struct {
 }
 
 type Handlers struct {
-	Conf      *configuration.Configuration
-	Storage   service.Storage
+	Conf    *configuration.Configuration
+	Storage service.Storage
 }
 
 func (h *Handlers) MarathonEventHandler(event MarathonEvent) {

--- a/services/event_bus/event_handler.go
+++ b/services/event_bus/event_handler.go
@@ -1,10 +1,10 @@
 package event_bus
 
 import (
-	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
 	"github.com/QubitProducts/bamboo/configuration"
 	"github.com/QubitProducts/bamboo/services/haproxy"
 	"github.com/QubitProducts/bamboo/services/template"
+	"github.com/QubitProducts/bamboo/services/service"
 	"io/ioutil"
 	"log"
 	"os"
@@ -30,7 +30,7 @@ type ServiceEvent struct {
 
 type Handlers struct {
 	Conf      *configuration.Configuration
-	Zookeeper *zk.Conn
+	Storage   service.Storage
 }
 
 func (h *Handlers) MarathonEventHandler(event MarathonEvent) {
@@ -52,7 +52,7 @@ func init() {
 		log.Println("Starting update loop")
 		for {
 			h := <-updateChan
-			handleHAPUpdate(h.Conf, h.Zookeeper)
+			handleHAPUpdate(h.Conf, h.Storage)
 		}
 	}()
 }
@@ -73,9 +73,9 @@ func queueUpdate(h *Handlers) {
 	<-queueUpdateSem
 }
 
-func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) {
+func handleHAPUpdate(conf *configuration.Configuration, storage service.Storage) {
 	reloadStart := time.Now()
-	reloaded, err := ensureLatestConfig(conf, conn)
+	reloaded, err := ensureLatestConfig(conf, storage)
 
 	if err != nil {
 		conf.StatsD.Increment(1.0, "haproxy.reload.error", 1)
@@ -91,8 +91,8 @@ func handleHAPUpdate(conf *configuration.Configuration, conn *zk.Conn) {
 }
 
 // For values of 'latest' conforming to general relativity.
-func ensureLatestConfig(conf *configuration.Configuration, conn *zk.Conn) (reloaded bool, err error) {
-	content, err := generateConfig(conf.HAProxy.TemplatePath, conf, conn)
+func ensureLatestConfig(conf *configuration.Configuration, storage service.Storage) (reloaded bool, err error) {
+	content, err := generateConfig(conf.HAProxy.TemplatePath, conf, storage)
 	if err != nil {
 		return
 	}
@@ -118,14 +118,14 @@ func ensureLatestConfig(conf *configuration.Configuration, conn *zk.Conn) (reloa
 }
 
 // Generates the new config to be written
-func generateConfig(templatePath string, conf *configuration.Configuration, conn *zk.Conn) (config string, err error) {
+func generateConfig(templatePath string, conf *configuration.Configuration, storage service.Storage) (config string, err error) {
 	templateContent, err := ioutil.ReadFile(templatePath)
 	if err != nil {
 		log.Println("Failed to read template contents")
 		return
 	}
 
-	templateData, err := haproxy.GetTemplateData(conf, conn)
+	templateData, err := haproxy.GetTemplateData(conf, storage)
 	if err != nil {
 		log.Println("Failed to retrieve template data")
 		return

--- a/services/haproxy/haproxy.go
+++ b/services/haproxy/haproxy.go
@@ -1,7 +1,6 @@
 package haproxy
 
 import (
-	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
 	conf "github.com/QubitProducts/bamboo/configuration"
 	"github.com/QubitProducts/bamboo/services/marathon"
 	"github.com/QubitProducts/bamboo/services/service"
@@ -12,7 +11,7 @@ type templateData struct {
 	Services map[string]service.Service
 }
 
-func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (*templateData, error) {
+func GetTemplateData(config *conf.Configuration, storage service.Storage) (*templateData, error) {
 
 	apps, err := marathon.FetchApps(config.Marathon, config)
 
@@ -20,11 +19,15 @@ func GetTemplateData(config *conf.Configuration, conn *zk.Conn) (*templateData, 
 		return nil, err
 	}
 
-	services, err := service.All(conn, config.Bamboo.Zookeeper)
-
+	services, err := storage.All()
 	if err != nil {
 		return nil, err
 	}
 
-	return &templateData{apps, services}, nil
+	byName := make(map[string]service.Service)
+	for _, service := range services {
+		byName[service.Id] = service
+	}
+
+	return &templateData{apps, byName}, nil
 }

--- a/services/service/representation.go
+++ b/services/service/representation.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ServiceRepr interface {
+	Service() Service
+	Serialize() ([]byte, error)
+}
+
+// ParseServiceRepr attempts parse using each of the ReprParsers in turn. Returns the first
+// result to not error, or the error from the last parser
+func ParseServiceRepr(body []byte, path string) (repr ServiceRepr, err error) {
+	reprParsers := [](func([]byte, string) (ServiceRepr, error)){
+		ParseV2ServiceRepr,
+		ParseV1ServiceRepr,
+	}
+
+	for _, parser := range reprParsers {
+		repr, err = parser(body, path)
+
+		if err == nil {
+			return
+		}
+	}
+	return nil, err
+}
+
+type V1ServiceRepr struct {
+	ID  string
+	Acl string
+}
+
+func ParseV1ServiceRepr(body []byte, path string) (repr ServiceRepr, err error) {
+	return &V1ServiceRepr{
+		ID:  path,
+		Acl: string(body),
+	}, nil
+}
+
+func (v1 *V1ServiceRepr) Service() Service {
+	return Service{
+		Id:     v1.ID,
+		Acl:    v1.Acl,
+		Config: map[string]string{"Acl": v1.Acl},
+	}
+}
+
+func (v1 *V1ServiceRepr) Serialize() ([]byte, error) {
+	return []byte(v1.Acl), nil
+}
+
+type V2ServiceRepr struct {
+	ID      string            `json:"-"`
+	Version string            `json:"version"` // 2 is only valid version for V2ServiceRepr
+	Config  map[string]string `json:"config"`
+}
+
+func ParseV2ServiceRepr(body []byte, path string) (ServiceRepr, error) {
+	var repr V2ServiceRepr
+	err := json.Unmarshal(body, &repr)
+	if err != nil {
+		return nil, err
+	}
+	if repr.Version != "2" {
+		return nil, fmt.Errorf("Service version is not 2 (%s)", repr.Version)
+	}
+	repr.ID = path
+
+	return &repr, nil
+}
+
+func (v2 *V2ServiceRepr) Service() Service {
+	acl, _ := v2.Config["Acl"]
+	return Service{
+		Id:     v2.ID,
+		Acl:    acl,
+		Config: v2.Config,
+	}
+}
+
+func (v2 *V2ServiceRepr) Serialize() ([]byte, error) {
+	return json.Marshal(&v2)
+}

--- a/services/service/representation.go
+++ b/services/service/representation.go
@@ -59,7 +59,7 @@ type V2ServiceRepr struct {
 }
 
 func MakeV2ServiceRepr(service Service) *V2ServiceRepr {
-	config := make(map[string]string, len(service.Config) + 1)
+	config := make(map[string]string, len(service.Config)+1)
 	for k, v := range service.Config {
 		config[k] = v
 	}
@@ -71,9 +71,9 @@ func MakeV2ServiceRepr(service Service) *V2ServiceRepr {
 
 func NewV2ServiceRepr(appID string, config map[string]string) *V2ServiceRepr {
 	return &V2ServiceRepr{
-		ID: appID,
+		ID:      appID,
 		Version: "2",
-		Config: config,
+		Config:  config,
 	}
 }
 

--- a/services/service/representation.go
+++ b/services/service/representation.go
@@ -58,6 +58,25 @@ type V2ServiceRepr struct {
 	Config  map[string]string `json:"config"`
 }
 
+func MakeV2ServiceRepr(service Service) *V2ServiceRepr {
+	config := make(map[string]string, len(service.Config) + 1)
+	for k, v := range service.Config {
+		config[k] = v
+	}
+	if service.Acl != "" {
+		config["Acl"] = service.Acl
+	}
+	return NewV2ServiceRepr(service.Id, config)
+}
+
+func NewV2ServiceRepr(appID string, config map[string]string) *V2ServiceRepr {
+	return &V2ServiceRepr{
+		ID: appID,
+		Version: "2",
+		Config: config,
+	}
+}
+
 func ParseV2ServiceRepr(body []byte, path string) (ServiceRepr, error) {
 	var repr V2ServiceRepr
 	err := json.Unmarshal(body, &repr)

--- a/services/service/representation_test.go
+++ b/services/service/representation_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 	"math/rand"
+	"reflect"
+	"testing/quick"
 
 	. "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"
-
-	//"github.com/QubitProducts/bamboo/configuration"
 )
 
 // Yanked off http://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
@@ -155,6 +155,20 @@ func TestV2ServiceRepr(t *testing.T) {
 					So(service.Config["arb"], ShouldEqual, "barb")
 				})
 			})
+		})
+	})
+
+	Convey("#MakeV2ServiceRepr", t, func() {
+		Convey("MakeV2ServiceRepr and V2ServiceRepr.Service should compose to identity", func() {
+			property := func(s Service) bool {
+				// The generator may create services with different .Acl and .Conf["Acl"]
+				s.Config["Acl"] = s.Acl
+				s2 := MakeV2ServiceRepr(s).Service()
+				return reflect.DeepEqual(s, s2)
+			}
+
+			err := quick.Check(property, nil)
+			So(err, ShouldBeNil)
 		})
 	})
 }

--- a/services/service/representation_test.go
+++ b/services/service/representation_test.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"fmt"
-	"testing"
 	"math/rand"
 	"reflect"
+	"testing"
 	"testing/quick"
 
 	. "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"

--- a/services/service/representation_test.go
+++ b/services/service/representation_test.go
@@ -1,0 +1,227 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+	"math/rand"
+
+	. "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"
+
+	//"github.com/QubitProducts/bamboo/configuration"
+)
+
+// Yanked off http://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6
+	letterIdxMask = 1<<letterIdxBits - 1
+	letterIdxMax  = 63 / letterIdxBits
+)
+
+func randString(n int) string {
+	b := make([]byte, n)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}
+
+func orPanic(err error) {
+	if err != nil {
+		panic(fmt.Sprintf("Error! %s", err))
+	}
+}
+
+func TestV1ServiceRepr(t *testing.T) {
+	Convey("#ParseV1ServiceRepr", t, func() {
+		Convey("when we parse an arbitrary string", func() {
+			str := randString(128)
+			path := randString(8)
+
+			repr, err := ParseV1ServiceRepr([]byte(str), path)
+
+			Convey("it should not error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("it should be a V1ServiceRepr", func() {
+				So(repr, ShouldHaveSameTypeAs, &V1ServiceRepr{})
+			})
+
+			Convey("when we create a service from the repr", func() {
+				service := repr.Service()
+
+				Convey("it should have the same id as the passed path", func() {
+					So(service.Id, ShouldEqual, path)
+				})
+
+				Convey("it should have the same ACL as the passed body", func() {
+					So(service.Acl, ShouldEqual, str)
+				})
+
+				Convey("it should have no other config entries", func() {
+					acl, ok := service.Config["Acl"]
+					So(ok, ShouldBeTrue)
+					So(acl, ShouldNotBeBlank)
+					So(len(service.Config), ShouldEqual, 1)
+				})
+			})
+
+		})
+	})
+}
+
+func TestV2ServiceRepr(t *testing.T) {
+	Convey("#ParseV1ServiceRepr", t, func() {
+		Convey("when we parse an invalid string", func() {
+			str := "}{" + randString(128)
+			path := randString(8)
+
+			_, err := ParseV2ServiceRepr([]byte(str), path)
+
+			Convey("it should error", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("when we parse a json blob with an incorrect version", func() {
+			path := randString(8)
+			body := []byte(`{"version": "3", "config": {}}`)
+			_, err := ParseV2ServiceRepr(body, path)
+
+			Convey("it should error", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("when we parse a json blob with a correct version and no config", func() {
+			path := randString(8)
+			body := []byte(`{"version": "2", "config": {}}`)
+			repr, err := ParseV2ServiceRepr(body, path)
+
+			Convey("it should not error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("when we create a service from the repr", func() {
+				service := repr.Service()
+
+				Convey("it should have the same id as the passed path", func() {
+					So(service.Id, ShouldEqual, path)
+				})
+
+				Convey("it should have no ACL", func() {
+					So(service.Acl, ShouldBeBlank)
+				})
+
+				Convey("it should have no config value", func() {
+					So(len(service.Config), ShouldEqual, 0)
+				})
+			})
+		})
+
+		Convey("when we parse a json blob with a correct version and a complete config", func() {
+			path := randString(8)
+			body := []byte(`{"version": "2", "config": {"Acl": "foo", "arb": "barb"}}`)
+			repr, err := ParseV2ServiceRepr(body, path)
+
+			Convey("it should not error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("when we create a service from the repr", func() {
+				service := repr.Service()
+
+				Convey("it should have the same id as the passed path", func() {
+					So(service.Id, ShouldEqual, path)
+				})
+
+				Convey("it should have an ACL", func() {
+					So(service.Acl, ShouldEqual, "foo")
+				})
+
+				Convey("it should have an additional config value", func() {
+					So(len(service.Config), ShouldEqual, 2)
+					So(service.Config["arb"], ShouldEqual, "barb")
+				})
+			})
+		})
+	})
+}
+
+func TestParseServiceRepr(t *testing.T) {
+	Convey("#ParseServiceRepr", t, func() {
+		Convey("when we parse an invalid json string", func() {
+			path := randString(8)
+			body := []byte("}{" + randString(128))
+
+			repr, err := ParseServiceRepr([]byte(body), path)
+
+			Convey("it should not error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("it should be a V1ServiceRepr", func() {
+				So(repr, ShouldHaveSameTypeAs, &V1ServiceRepr{})
+			})
+
+			Convey("when we create a service from the repr", func() {
+				service := repr.Service()
+
+				Convey("it should ave the same id as the passed path", func() {
+					So(service.Id, ShouldEqual, path)
+				})
+
+				Convey("its acl should be the body", func() {
+					So(service.Acl, ShouldEqual, string(body))
+				})
+
+				Convey("it should have no other config values", func() {
+					So(len(service.Config), ShouldEqual, 1)
+				})
+			})
+		})
+
+		Convey("when we parse a v2 repr", func() {
+			path := randString(8)
+			body := []byte(`{"version": "2", "config": {"Acl": "foo", "arb": "barb"}}`)
+
+			repr, err := ParseServiceRepr(body, path)
+
+			Convey("it should not error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("it should be a V2ServiceRepr", func() {
+				So(repr, ShouldHaveSameTypeAs, &V2ServiceRepr{})
+			})
+
+			Convey("when we create a service from the repr", func() {
+				service := repr.Service()
+
+				Convey("it should have the same id as the passed path", func() {
+					So(service.Id, ShouldEqual, path)
+				})
+
+				Convey("its acl should be foo", func() {
+					So(service.Acl, ShouldEqual, "foo")
+				})
+
+				Convey("it should have one other config value", func() {
+					So(len(service.Config), ShouldEqual, 2)
+					So(service.Config["arb"], ShouldEqual, "barb")
+				})
+			})
+		})
+	})
+}

--- a/services/service/service.go
+++ b/services/service/service.go
@@ -1,114 +1,16 @@
 package service
 
-import (
-	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
-	conf "github.com/QubitProducts/bamboo/configuration"
-	"net/url"
-	"strings"
-)
-
 type Service struct {
 	Id     string            `param:"id"`
+	// Acl is present for backwards compatability, and should not be written to.
+	// Instead, write to the "Acl" key in Config
 	Acl    string            `param:"acl"`
 	Config map[string]string `param:"config"`
 }
 
-func All(conn *zk.Conn, zkConf conf.Zookeeper) (map[string]Service, error) {
-
-	err := ensurePathExists(conn, zkConf.Path)
-	if err != nil {
-		return nil, err
-	}
-
-	services := map[string]Service{}
-	keys, _, err2 := conn.Children(zkConf.Path)
-
-	if err2 != nil {
-		return nil, err2
-	}
-
-	for _, childPath := range keys {
-		bite, _, e := conn.Get(zkConf.Path + "/" + childPath)
-		if e != nil {
-			return nil, e
-		}
-		appId, _ := unescapeSlashes(childPath)
-		services[appId] = Service{Id: appId, Acl: string(bite)}
-	}
-	return services, nil
-}
-
-/*
-   Read ZK ACL:
-   http://zookeeper.apache.org/doc/trunk/zookeeperProgrammers.html#sc_ACLPermissions
-*/
-func Create(conn *zk.Conn, zkConf conf.Zookeeper, appId string, domainValue string) (string, error) {
-	path := concatPath(zkConf.Path, validateAppId(appId))
-	resPath, err := conn.Create(path, []byte(domainValue), 0, defaultACL())
-	if err != nil {
-		return "", err
-	}
-
-	return resPath, nil
-}
-
-func Put(conn *zk.Conn, zkConf conf.Zookeeper, appId string, domainValue string) (*zk.Stat, error) {
-	path := concatPath(zkConf.Path, validateAppId(appId))
-	err := ensurePathExists(conn, path)
-	if err != nil {
-		return nil, err
-	}
-
-	stats, err := conn.Set(path, []byte(domainValue), -1)
-	if err != nil {
-		return nil, err
-	}
-
-	// Force triger an event on parent
-	conn.Set(zkConf.Path, []byte{}, -1)
-
-	return stats, nil
-}
-
-func Delete(conn *zk.Conn, zkConf conf.Zookeeper, appId string) error {
-	path := concatPath(zkConf.Path, validateAppId(appId))
-	return conn.Delete(path, -1)
-}
-
-func concatPath(parentPath string, appId string) string {
-	return parentPath + "/" + escapeSlashes(appId)
-}
-
-func ensurePathExists(conn *zk.Conn, path string) error {
-	pathExists, _, _ := conn.Exists(path)
-	if pathExists {
-		return nil
-	}
-
-	_, err := conn.Create(path, []byte{}, 0, defaultACL())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func defaultACL() []zk.ACL {
-	return []zk.ACL{zk.ACL{Perms: zk.PermAll, Scheme: "world", ID: "anyone"}}
-}
-
-func validateAppId(appId string) string {
-	if strings.HasPrefix(appId, "/") {
-		return appId
-	} else {
-		return "/" + appId
-	}
-}
-
-func escapeSlashes(id string) string {
-	return url.QueryEscape(id)
-}
-
-func unescapeSlashes(id string) (string, error) {
-	return url.QueryUnescape(id)
+// The storage primitives required by Bamboo from the storage backend
+type Storage interface {
+	All() ([]Service, error)
+	Upsert(service Service) error
+	Delete(serviceId string) error
 }

--- a/services/service/service.go
+++ b/services/service/service.go
@@ -1,7 +1,7 @@
 package service
 
 type Service struct {
-	Id     string            `param:"id"`
+	Id string `param:"id"`
 	// Acl is present for backwards compatability, and should not be written to.
 	// Instead, write to the "Acl" key in Config
 	Acl    string            `param:"acl"`

--- a/services/service/service.go
+++ b/services/service/service.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Service struct {
-	Id  string `param:"id"`
-	Acl string `param:"acl"`
+	Id     string            `param:"id"`
+	Acl    string            `param:"acl"`
+	Config map[string]string `param:"config"`
 }
 
 func All(conn *zk.Conn, zkConf conf.Zookeeper) (map[string]Service, error) {

--- a/services/service/zookeeper.go
+++ b/services/service/zookeeper.go
@@ -60,7 +60,7 @@ func (z *ZKStorage) All() (services []Service, err error) {
 }
 
 func (z *ZKStorage) Upsert(service Service) (err error) {
-	repr := NewV2ServiceRepr(service.Id, service.Config)
+	repr := MakeV2ServiceRepr(service)
 
 	body, err := repr.Serialize()
 	if err != nil {

--- a/services/service/zookeeper.go
+++ b/services/service/zookeeper.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
+	conf "github.com/QubitProducts/bamboo/configuration"
+	"net/url"
+	"log"
+)
+
+type ZKStorage struct {
+	conn *zk.Conn
+	conf conf.Zookeeper
+	acl []zk.ACL
+}
+
+func NewZKStorage(conn *zk.Conn, conf conf.Zookeeper) (s *ZKStorage, err error) {
+	s = &ZKStorage{
+		conn: conn,
+		conf: conf,
+		acl: defaultACL(),
+	}
+	err = s.ensurePathExists()
+	return s, err
+}
+
+func (z *ZKStorage) All() (services []Service, err error) {
+	err = z.ensurePathExists()
+	if err != nil {
+		return
+	}
+
+	keys, _, err := z.conn.Children(z.conf.Path)
+	if err != nil {
+		return
+	}
+
+	services = make([]Service, 0, len(keys))
+	for _, childPath := range keys {
+		body, _, err := z.conn.Get(z.conf.Path + "/" + childPath)
+		if err != nil {
+			return nil, err
+		}
+
+		path, err := unescapePath(childPath)
+		if err != nil {
+			return nil, err
+		}
+
+		// We tolerate being unable to decode a service body, as may be new version running simultaneously
+		repr, err := ParseServiceRepr(body, path)
+		if err != nil {
+			log.Printf("Failed to parse service at %v: %v", path, err)
+			continue
+		}
+
+		services = append(services, repr.Service())
+	}
+
+	return
+}
+
+func (z *ZKStorage) Upsert(service Service) (err error) {
+	repr := NewV2ServiceRepr(service.Id, service.Config)
+
+	body, err := repr.Serialize()
+	if err != nil {
+		return
+	}
+
+	err = z.ensurePathExists()
+	if err != nil {
+		return err
+	}
+
+	path := z.servicePath(service.Id)
+
+	ok, _, err := z.conn.Exists(path)
+	if err != nil {
+		return
+	}
+
+	if ok {
+		_, err = z.conn.Set(path, body, -1)
+		if err != nil {
+			log.Print("Failed to set path", err)
+			return
+		}
+
+		// Trigger an event on the parent
+		_, err = z.conn.Set(z.conf.Path, []byte{}, -1)
+		if err != nil {
+			log.Print("Failed to trigger event on parent", err)
+			err = nil
+		}
+
+	} else {
+		_, err = z.conn.Create(path, body, 0, z.acl)
+		if err != nil {
+			log.Print("Failed to set create", err)
+			return
+		}
+	}
+	return
+}
+
+func (z *ZKStorage) Delete(serviceId string) error {
+	path := z.servicePath(serviceId)
+	return z.conn.Delete(path, -1)
+}
+
+func (z *ZKStorage) servicePath(id string) string {
+	return z.conf.Path + "/" + escapePath(id)
+}
+
+func (z *ZKStorage) ensurePathExists() error {
+	pathExists, _, _ := z.conn.Exists(z.conf.Path)
+	if pathExists {
+		return nil
+	}
+
+	// This is a fairly rare, and fairly critical, operation, so I'm going to be verbose
+	log.Print("Creating base zk path", z.conf.Path)
+	_, err := z.conn.Create(z.conf.Path, []byte{}, 0, z.acl)
+	if err != nil {
+		log.Print("Failed to create base zk path", err)
+	}
+
+	return err
+}
+
+func defaultACL() []zk.ACL {
+	return []zk.ACL{zk.ACL{Perms: zk.PermAll, Scheme: "world", ID: "anyone"}}
+}
+
+func escapePath(path string) string {
+	return url.QueryEscape(path)
+}
+
+func unescapePath(path string) (string, error) {
+	return url.QueryUnescape(path)
+}

--- a/services/service/zookeeper.go
+++ b/services/service/zookeeper.go
@@ -3,21 +3,21 @@ package service
 import (
 	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
 	conf "github.com/QubitProducts/bamboo/configuration"
-	"net/url"
 	"log"
+	"net/url"
 )
 
 type ZKStorage struct {
 	conn *zk.Conn
 	conf conf.Zookeeper
-	acl []zk.ACL
+	acl  []zk.ACL
 }
 
 func NewZKStorage(conn *zk.Conn, conf conf.Zookeeper) (s *ZKStorage, err error) {
 	s = &ZKStorage{
 		conn: conn,
 		conf: conf,
-		acl: defaultACL(),
+		acl:  defaultACL(),
 	}
 	err = s.ensurePathExists()
 	return s, err

--- a/services/service/zookeeper_test.go
+++ b/services/service/zookeeper_test.go
@@ -1,0 +1,272 @@
+package service
+
+import (
+	"testing"
+	. "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"
+
+	"time"
+	"log"
+
+	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
+	"github.com/QubitProducts/bamboo/configuration"
+)
+
+var zkTimeout = time.Second
+var zkConf = configuration.Zookeeper{
+	Host: "localhost:2181",
+	Path: "/test-bamboo",
+	ReportingDelay: 1,
+}
+
+
+func cleanZK(conn *zk.Conn) {
+	deleteRecursive(conn, zkConf.Path)
+}
+
+func deleteRecursive(conn *zk.Conn, path string) {
+	children, _, err := conn.Children(path)
+	if err != nil {
+		log.Printf("failed to get children %s: %s", path, err)
+		return
+	}
+	for _, child := range children {
+		deleteRecursive(conn, path + "/" + child)
+	}
+	err = conn.Delete(path, -1)
+	if err != nil {
+		log.Printf("failed to delete %s: %s", path, err)
+	}
+}
+
+func loadToZK(conn *zk.Conn, data [][2]string) {
+	for _, entry := range data {
+		k := entry[0]
+		v := entry[1]
+		_, err := conn.Create(k, []byte(v), 0, defaultACL())
+		orPanic(err)
+	}
+}
+
+func TestZKStorage(t *testing.T) {
+	conn, _, err := zk.Connect(zkConf.ConnectionString(), zkTimeout)
+	orPanic(err)
+
+	Convey("#NewZKStorage", t, func() {
+		cleanZK(conn)
+		s, err := NewZKStorage(conn, zkConf)
+
+		So(err, ShouldBeNil)
+
+		Convey("it should implement the Storage interface", func() {
+			_, ok := interface{}(s).(Storage)
+			So(ok, ShouldBeTrue)
+		})
+
+		Convey("it should have created the base path", func() {
+			exists, _, err := conn.Exists(zkConf.Path)
+
+			So(err, ShouldBeNil)
+			So(exists, ShouldBeTrue)
+		})
+	})
+
+	Convey("#ZKStorage.All", t, func() {
+		s, err := NewZKStorage(conn, zkConf)
+		So(err, ShouldBeNil)
+
+		Convey("when I get all in an empty zookeeper", func() {
+			cleanZK(conn)
+			entries, err := s.All()
+
+			So(err, ShouldBeNil)
+
+			Convey("there should be no entries", func() {
+				So(len(entries), ShouldEqual, 0)
+			})
+		})
+
+		Convey("when I get all in a legacy/v1 zookeeper", func() {
+			cleanZK(conn)
+			loadToZK(conn, [][2]string{
+				[2]string{zkConf.Path, ""},
+				[2]string{zkConf.Path + "/test", "hdr(host) -i foo"},
+				[2]string{zkConf.Path + "/test2", "fozbaz"},
+			})
+
+			entries, err := s.All()
+
+			So(err, ShouldBeNil)
+
+			Convey("there should be the correct number of entries", func() {
+				So(len(entries), ShouldEqual, 2)
+			})
+
+			Convey("there should be an entry with the id test", func() {
+				var test Service
+				found := false
+				for _, i := range entries {
+					if i.Id == "test" {
+						test = i
+						found = true
+						break
+					}
+				}
+				So(found, ShouldBeTrue)
+
+				Convey("which should have an acl 'hdr(host) -i foo'", func() {
+					So(test.Acl, ShouldEqual, "hdr(host) -i foo")
+					So(test.Config["Acl"], ShouldEqual, "hdr(host) -i foo")
+				})
+			})
+		})
+
+		Convey("when I get all in a mixed v1/v2 zookeeper", func() {
+			cleanZK(conn)
+			loadToZK(conn, [][2]string{
+				[2]string{zkConf.Path, ""},
+				[2]string{zkConf.Path + "/test", `{"version": "2", "config": {"Acl": "foo", "arb": "barb"}}`},
+				[2]string{zkConf.Path + "/test2", "fozbaz"},
+			})
+
+			entries, err := s.All()
+
+			So(err, ShouldBeNil)
+
+			Convey("there should be the correct number of entries", func() {
+				So(len(entries), ShouldEqual, 2)
+			})
+
+			Convey("there should be an entry with the id test", func() {
+				var test Service
+				found := false
+				for _, i := range entries {
+					if i.Id == "test" {
+						test = i
+						found = true
+						break
+					}
+				}
+				So(found, ShouldBeTrue)
+
+				Convey("which should have an acl 'foo'", func() {
+					So(test.Acl, ShouldEqual, "foo")
+					So(test.Config["Acl"], ShouldEqual, "foo")
+				})
+
+				Convey("which should have a config entry 'arb'", func() {
+					So(test.Config["arb"], ShouldEqual, "barb")
+				})
+			})
+		})
+	})
+
+	Convey("#ZKStorage.Upsert", t, func() {
+		s, err := NewZKStorage(conn, zkConf)
+		So(err, ShouldBeNil)
+
+		testService := Service{
+			Id: "test",
+			Config: map[string]string{
+				"Acl": "foo",
+				"barst": "carst",
+			},
+		}
+
+		Convey("when I insert into an empty key", func() {
+			cleanZK(conn)
+			err := s.Upsert(testService)
+			So(err, ShouldBeNil)
+
+			entries, err := s.All()
+			So(err, ShouldBeNil)
+
+			Convey("there should be 1 entry", func() {
+				So(len(entries), ShouldEqual, 1)
+
+				readEntry := entries[0]
+
+				Convey("which should have an Acl 'foo'", func() {
+					So(readEntry.Acl, ShouldEqual, "foo")
+					So(readEntry.Config["Acl"], ShouldEqual, "foo")
+				})
+
+				Convey("which should have a config entry 'barst'", func() {
+					So(readEntry.Config["barst"], ShouldEqual, "carst")
+				})
+			})
+		})
+
+		Convey("when I insert into an existing key", func() {
+			cleanZK(conn)
+			loadToZK(conn, [][2]string{
+				[2]string{zkConf.Path, ""},
+				[2]string{zkConf.Path + "/test", "fozbaz"},
+			})
+
+			err := s.Upsert(testService)
+			So(err, ShouldBeNil)
+
+			entries, err := s.All()
+			So(err, ShouldBeNil)
+
+			Convey("there should be 1 entry", func() {
+				So(len(entries), ShouldEqual, 1)
+
+				readEntry := entries[0]
+
+				Convey("which should have an Acl 'foo'", func() {
+					So(readEntry.Acl, ShouldEqual, "foo")
+					So(readEntry.Config["Acl"], ShouldEqual, "foo")
+				})
+
+				Convey("which should have a config entry 'barst'", func() {
+					So(readEntry.Config["barst"], ShouldEqual, "carst")
+				})
+			})
+		})
+	})
+
+	Convey("#ZKStorage.Delete", t, func() {
+		s, err := NewZKStorage(conn, zkConf)
+		So(err, ShouldBeNil)
+
+
+		Convey("when I delete the only service", func() {
+			cleanZK(conn)
+			loadToZK(conn, [][2]string{
+				[2]string{zkConf.Path, ""},
+				[2]string{zkConf.Path + "/test", "fozbaz"},
+			})
+
+			err := s.Delete("test")
+			So(err, ShouldBeNil)
+
+
+			Convey("there should be zero entries", func() {
+				entries, err := s.All()
+				So(err, ShouldBeNil)
+
+				So(len(entries), ShouldEqual, 0)
+			})
+		})
+
+		Convey("when I delete an non-existant service", func() {
+			cleanZK(conn)
+
+			err := s.Delete("test")
+
+			Convey("it should error", func() {
+				So(err, ShouldNotBeNil)
+			})
+			So(err, ShouldNotBeNil)
+
+
+			Convey("there should be zero entries", func() {
+				entries, err := s.All()
+				So(err, ShouldBeNil)
+
+				So(len(entries), ShouldEqual, 0)
+			})
+		})
+	})
+}

--- a/services/service/zookeeper_test.go
+++ b/services/service/zookeeper_test.go
@@ -1,11 +1,11 @@
 package service
 
 import (
-	"testing"
 	. "github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"
+	"testing"
 
-	"time"
 	"log"
+	"time"
 
 	"github.com/QubitProducts/bamboo/Godeps/_workspace/src/github.com/samuel/go-zookeeper/zk"
 	"github.com/QubitProducts/bamboo/configuration"
@@ -13,11 +13,10 @@ import (
 
 var zkTimeout = time.Second
 var zkConf = configuration.Zookeeper{
-	Host: "localhost:2181",
-	Path: "/test-bamboo",
+	Host:           "localhost:2181",
+	Path:           "/test-bamboo",
 	ReportingDelay: 1,
 }
-
 
 func cleanZK(conn *zk.Conn) {
 	deleteRecursive(conn, zkConf.Path)
@@ -30,7 +29,7 @@ func deleteRecursive(conn *zk.Conn, path string) {
 		return
 	}
 	for _, child := range children {
-		deleteRecursive(conn, path + "/" + child)
+		deleteRecursive(conn, path+"/"+child)
 	}
 	err = conn.Delete(path, -1)
 	if err != nil {
@@ -167,7 +166,7 @@ func TestZKStorage(t *testing.T) {
 		testService := Service{
 			Id: "test",
 			Config: map[string]string{
-				"Acl": "foo",
+				"Acl":   "foo",
 				"barst": "carst",
 			},
 		}
@@ -230,7 +229,6 @@ func TestZKStorage(t *testing.T) {
 		s, err := NewZKStorage(conn, zkConf)
 		So(err, ShouldBeNil)
 
-
 		Convey("when I delete the only service", func() {
 			cleanZK(conn)
 			loadToZK(conn, [][2]string{
@@ -240,7 +238,6 @@ func TestZKStorage(t *testing.T) {
 
 			err := s.Delete("test")
 			So(err, ShouldBeNil)
-
 
 			Convey("there should be zero entries", func() {
 				entries, err := s.All()
@@ -259,7 +256,6 @@ func TestZKStorage(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 			So(err, ShouldNotBeNil)
-
 
 			Convey("there should be zero entries", func() {
 				entries, err := s.All()

--- a/webapp/app/components/service-form/service-form-ctrl.js
+++ b/webapp/app/components/service-form/service-form-ctrl.js
@@ -30,7 +30,9 @@ module.exports = ["$scope", "$modal", "$rootScope", function ($scope, $modal, $r
     $scope.loading = true;
     $scope.makeRequest({
         id: $scope.service.id,
-        acl: $scope.service.acl
+        config: {
+          Acl: $scope.service.acl
+        }
       })
      .then(handleSuccess, handleError);
   };


### PR DESCRIPTION
This allows users to specify whatever they want in their bamboo service values by changing the service definition to have a `Config map[string]string`. This means that I can, in addition to having an ACL, set things like `RequiresWebsockets` or `HealthCheckInterval`, and in the template act on them by testing `$service.Conf.RequiresWebsockets` or `$service.Conf.HealthCheckInterval`.

This is fully backwards compatible, with `$service.Conf.Acl` and `$service.Acl` being kept in sync. The existing mappings do not change unless updated, allowing easy downgrades, should this cause problems. Any applications using the API directly will also still work (see `MakeV2ServiceRepr` for details on how creation is backwards compatible and `V2ServiceRepr.Service` for the inverse).

The UI has not been updated. I'd like to support this, but I have no love for angular, and would rather not spend too long fighting with it when I'm sure someone else can do it much more efficiently.

The majority of this diff comes from me moving away from passing around a raw ZK connection, and instead encapsulating it behind a `service.Storage` interface. There's also quite a few lines changed around handling multiple representations concurrently, and a ton of tests for these two main changes.

Ongoing:
- [x] Dev & staging test

Pending:
- [ ] New UI Design
- [ ] New UI Implementation
- [x] All regressions resolved