### PR TITLE
Update to ubuntu 15.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:15.10
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV GOPATH /opt/go


### PR DESCRIPTION
Update to get new golang

Fixes the bug when building the docker image.

```
Step 9 : RUN go get github.com/tools/godep &&     go get -t github.com/smartystreets/goconvey &&     go build &&     ln -s /opt/go/src/github.com/QubitProducts/bamboo /var/bamboo &&     mkdir -p /run/haproxy &&     mkdir -p /var/log/supervisor
 ---> Running in 4f034c6ddb5a

# github.com/QubitProducts/bamboo

./bamboo.go:185: client.Timeout undefined (type *http.Client has no field or method Timeout)

The command '/bin/sh -c go get github.com/tools/godep &&     go get -t github.com/smartystreets/goconvey &&     go build &&     ln -s /opt/go/src/github.com/QubitProducts/bamboo /var/bamboo &&     mkdir -p /run/haproxy &&     mkdir -p /var/log/supervisor' returned a non-zero code: 2
```