### PR TITLE
Fix error with old version of package in apt cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:15.10
 ENV DEBIAN_FRONTEND noninteractive
 ENV GOPATH /opt/go
 
-RUN apt-get install -yqq software-properties-common && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq software-properties-common && \
     add-apt-repository -y ppa:vbernat/haproxy-1.5 && \
     apt-get update -yqq && \
     apt-get install -yqq haproxy golang git mercurial supervisor && \


### PR DESCRIPTION
Step 4 : RUN apt-get install -yqq software-properties-common &&     add-apt-repository -y ppa:vbernat/haproxy-1.5 &&     apt-get update -yqq &&     apt-get install -yqq haproxy golang git mercurial supervisor &&     rm -rf /var/lib/apt/lists/*
 ---> Running in 22077f4a3c63
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.9.2+zdfsg1-4ubuntu0.1_amd64.deb  404  Not Found

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
