### PR TITLE
Now using golang:1.6.2 as a base for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-FROM ubuntu:15.10
+FROM golang:1.6.2
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV GOPATH /opt/go
 
 RUN apt-get update -yqq && \
     apt-get install -yqq software-properties-common && \
-    add-apt-repository -y ppa:vbernat/haproxy-1.5 && \
-    apt-get update -yqq && \
-    apt-get install -yqq haproxy golang git mercurial supervisor && \
+    apt-get install -yqq haproxy git mercurial supervisor && \
     rm -rf /var/lib/apt/lists/*
 
-ADD . /opt/go/src/github.com/QubitProducts/bamboo
+ADD . /go/src/github.com/QubitProducts/bamboo
 ADD builder/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD builder/run.sh /run.sh
 
-WORKDIR /opt/go/src/github.com/QubitProducts/bamboo
+WORKDIR /go/src/github.com/QubitProducts/bamboo
 
 RUN go get github.com/tools/godep && \
     go get -t github.com/smartystreets/goconvey && \
     go build && \
-    ln -s /opt/go/src/github.com/QubitProducts/bamboo /var/bamboo && \
+    ln -s /go/src/github.com/QubitProducts/bamboo /var/bamboo && \
     mkdir -p /run/haproxy && \
     mkdir -p /var/log/supervisor
 

--- a/Dockerfile-deb
+++ b/Dockerfile-deb
@@ -1,16 +1,14 @@
-FROM ubuntu:14.04
+FROM golang:1.6.2
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV GOPATH /opt/go
 
 RUN apt-get update -yqq
 RUN apt-get install -yqq software-properties-common curl git mercurial ruby-dev gcc make
-RUN add-apt-repository -y ppa:ethereum/ethereum && apt-get update && apt-get -y install golang
 RUN gem install fpm
 
-ADD . /opt/go/src/github.com/QubitProducts/bamboo
+ADD . /go/src/github.com/QubitProducts/bamboo
 
-WORKDIR /opt/go/src/github.com/QubitProducts/bamboo
+WORKDIR /go/src/github.com/QubitProducts/bamboo
 RUN go get github.com/tools/godep && \
     go get -t github.com/smartystreets/goconvey && \
     go build


### PR DESCRIPTION
Hi there.

As stated in #200 , Go 1.6 may fix some issues. This PR changes the base image in Dockerfiles to switch to [golang:1.6.2](https://hub.docker.com/_/golang/).

Please note that `golang` image is based on `jessie-scm`, so your existing Dockerfiles were mainly compatible with it. `GOPATH` is `/go` on `golang` image, so i had to change this, and i also removed some (apparently ?) unused ppa repositories which would have not been compatible with `jessie-scm` anyway.

**Disclaimer** : i tested `Dockerfile` on our production cluster, works great. But i wasn't able to test `Dockerfile-deb`. Only a few minor changes, so i assume it won't break anything, but i would feel it safer if someone who uses it everyday could confirm that.

Thanks in adv. !