### PR TITLE
Prepend slash to service ID in DELETE

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -67,12 +67,17 @@ func (d *ServiceAPI) Put(params martini.Params, w http.ResponseWriter, r *http.R
 }
 
 func (d *ServiceAPI) Delete(params martini.Params, w http.ResponseWriter, r *http.Request) {
-	serviceId := params["_1"]
-	if !strings.HasPrefix(serviceId, "/") {
-		serviceId = "/" + serviceId
+	serviceID := params["_1"]
+	if len(serviceID) == 0 {
+		responseError(w, "can not use empty ID")
+		return
 	}
 
-	err := d.Storage.Delete(serviceId)
+	if !strings.HasPrefix(serviceID, "/") {
+		serviceID = "/" + serviceID
+	}
+
+	err := d.Storage.Delete(serviceID)
 	if err != nil {
 		responseError(w, err.Error())
 		return
@@ -89,6 +94,11 @@ func extractService(r *http.Request) (service.Service, error) {
 	if err != nil {
 		return serviceModel, errors.New("Unable to decode JSON request")
 	}
+
+	if len(serviceModel.Id) == 0 {
+		return serviceModel, errors.New("can not use empty ID")
+	}
+
 	if !strings.HasPrefix(serviceModel.Id, "/") {
 		serviceModel.Id = "/" + serviceModel.Id
 	}

--- a/api/service.go
+++ b/api/service.go
@@ -68,6 +68,10 @@ func (d *ServiceAPI) Put(params martini.Params, w http.ResponseWriter, r *http.R
 
 func (d *ServiceAPI) Delete(params martini.Params, w http.ResponseWriter, r *http.Request) {
 	serviceId := params["_1"]
+	if !strings.HasPrefix(serviceId, "/") {
+		serviceId = "/" + serviceId
+	}
+
 	err := d.Storage.Delete(serviceId)
 	if err != nil {
 		responseError(w, err.Error())


### PR DESCRIPTION
There is a small discrepancy in the current bamboo version in handling the ID between PUT and DELETE.

Create service `/some/service` using PUT:
```bash
$ http -v PUT http://localhost:8000/api/services/some/service Id=/some/service "Acl=path_beg /some/service"
PUT /api/services/some/service HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 56
Content-Type: application/json
Host: localhost:8000
User-Agent: HTTPie/0.9.3

{
    "Acl": "path_beg /some/service",
    "Id": "/some/service"
}

HTTP/1.1 200 OK
Content-Length: 67
Content-Type: application/json
Date: Wed, 22 Jun 2016 16:47:50 GMT

{
    "Acl": "path_beg /some/service",
    "Config": null,
    "Id": "/some/service"
}
```

Delete same service:
```bash
> http -v DELETE http://localhost:8000/api/services/some/service
DELETE /api/services/some/service HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 0
Host: localhost:8000
User-Agent: HTTPie/0.9.3



HTTP/1.1 400 Bad Request
Content-Length: 24
Content-Type: text/plain; charset=utf-8
Date: Wed, 22 Jun 2016 16:48:50 GMT
X-Content-Type-Options: nosniff

zk: node does not exist
```

This is because PUT and POST read the service-ID from the JSON payload and prepend a slash if the ID does not start with one. This fix just also adds the slash when using the DELETE request.

I noticed that there is also no input validation on the ID read from JSON, so if an empty string is passed it is converted to a single slash, which should probably also not happen.