### PR TITLE
Ignore event lines in event stream.

### DIFF
--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -253,6 +253,10 @@ func connectToMarathonEventStream(marathon, user, password string) <-chan []byte
 				continue
 			}
 
+			if strings.HasPrefix(line, "event: ") {
+				continue
+			}
+
 			if !strings.HasPrefix(line, "data: ") {
 				errorMsg := "Wrong event format: %s\n"
 				log.Printf(errorMsg, line)

--- a/main/bamboo/bamboo_test.go
+++ b/main/bamboo/bamboo_test.go
@@ -56,6 +56,11 @@ func TestConnectToMarathonEventStream(t *testing.T) {
 			count:   0,
 		},
 		{
+			desc:    "unexpected line",
+			handler: eventSourceHandler("unexpected line"),
+			count:   0,
+		},
+		{
 			desc:    "mixed content",
 			handler: eventSourceHandler("", "event: eventName", "data: payload", "", "", "event: eventName2", "data: payload2", ""),
 			count:   2,
@@ -65,6 +70,7 @@ func TestConnectToMarathonEventStream(t *testing.T) {
 			},
 		},
 	} {
+		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -177,6 +183,7 @@ func TestListenToMarathonEventStream(t *testing.T) {
 			},
 		},
 	} {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
The event stream seems to have three types of "lines":
- Empty lines sent in regular interval as "heartbeat"
- Lines starting with "event: " containing only the event type
- Lines starting with "data: " containing a JSON representation of the event

Currently the "event: " lines produce log output hinting that there was an error while they can be safely ignored (the event type is also present in the JSON).

Fixes #219 