### PR TITLE
Add tests for event stream loop

### DIFF
--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -211,14 +211,15 @@ func connectToMarathonEventStream(marathon, user, password string) <-chan []byte
 
 		eventsURL := marathon + "/v2/events"
 		req, err := http.NewRequest("GET", eventsURL, nil)
-		req.Header.Set("Accept", "text/event-stream")
-		if len(user) > 0 && len(password) > 0 {
-			req.SetBasicAuth(user, password)
-		}
 		if err != nil {
 			errorMsg := "An error occurred while creating request to Marathon events system: %s\n"
 			log.Printf(errorMsg, err)
 			return
+		}
+
+		req.Header.Set("Accept", "text/event-stream")
+		if len(user) > 0 && len(password) > 0 {
+			req.SetBasicAuth(user, password)
 		}
 
 		resp, err := client.Do(req)

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -197,8 +197,9 @@ type eventBusSink interface {
 }
 
 func listenToMarathonEventStreamLoop(conf *configuration.Configuration, sink eventBusSink, ticker <-chan time.Time) {
-	for _ = range ticker {
+	for range ticker {
 		for _, marathon := range conf.Marathon.Endpoints() {
+			log.Printf("Connecting event stream to %s", marathon)
 			ch := connectToMarathonEventStream(marathon, conf.Marathon.User, conf.Marathon.Password)
 			for payload := range ch {
 				sink.Notify(payload)
@@ -261,8 +262,6 @@ func connectToMarathonEventStream(marathon, user, password string) <-chan []byte
 			line = line[6:]
 			payloadChan <- []byte(line)
 		}
-
-		log.Println("Event stream connection was closed. Re-opening...")
 	}()
 
 	return payloadChan

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -188,63 +188,77 @@ func listenToZookeeper(conf configuration.Configuration, eventBus *event_bus.Eve
 }
 
 func listenToMarathonEventStream(conf *configuration.Configuration, sub api.EventSubscriptionAPI) {
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		for _ = range ticker.C {
+			for _, marathon := range conf.Marathon.Endpoints() {
+				ch := connectToMarathonEventStream(marathon, conf.Marathon.User, conf.Marathon.Password)
+				for payload := range ch {
+					sub.Notify(payload)
+				}
+			}
+		}
+	}()
+}
+
+func connectToMarathonEventStream(marathon, user, password string) <-chan []byte {
 	client := &http.Client{}
 	client.Timeout = 0 * time.Second
+	payloadChan := make(chan []byte)
 
-	for _, marathon := range conf.Marathon.Endpoints() {
-		ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		defer close(payloadChan)
+
 		eventsURL := marathon + "/v2/events"
-		go func() {
-			for _ = range ticker.C {
-				req, err := http.NewRequest("GET", eventsURL, nil)
-				req.Header.Set("Accept", "text/event-stream")
-				if len(conf.Marathon.User) > 0 && len(conf.Marathon.Password) > 0 {
-					req.SetBasicAuth(conf.Marathon.User, conf.Marathon.Password)
-				}
-				if err != nil {
-					errorMsg := "An error occurred while creating request to Marathon events system: %s\n"
+		req, err := http.NewRequest("GET", eventsURL, nil)
+		req.Header.Set("Accept", "text/event-stream")
+		if len(user) > 0 && len(password) > 0 {
+			req.SetBasicAuth(user, password)
+		}
+		if err != nil {
+			errorMsg := "An error occurred while creating request to Marathon events system: %s\n"
+			log.Printf(errorMsg, err)
+			return
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			errorMsg := "An error occurred while making a request to Marathon events system: %s\n"
+			log.Printf(errorMsg, err)
+			return
+		}
+
+		defer resp.Body.Close()
+
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err != io.EOF {
+					errorMsg := "An error occurred while reading Marathon event: %s\n"
 					log.Printf(errorMsg, err)
-					continue
 				}
-
-				resp, err := client.Do(req)
-				if err != nil {
-					errorMsg := "An error occurred while making a request to Marathon events system: %s\n"
-					log.Printf(errorMsg, err)
-					continue
-				}
-
-				defer resp.Body.Close()
-
-				reader := bufio.NewReader(resp.Body)
-				for {
-					line, err := reader.ReadString('\n')
-					if err != nil {
-						if err != io.EOF {
-							errorMsg := "An error occurred while reading Marathon event: %s\n"
-							log.Printf(errorMsg, err)
-						}
-						break
-					}
-
-					if len(strings.TrimSpace(line)) == 0 {
-						continue
-					}
-
-					if !strings.HasPrefix(line, "data: ") {
-						errorMsg := "Wrong event format: %s\n"
-						log.Printf(errorMsg, line)
-						continue
-					}
-
-					line = line[6:]
-					sub.Notify([]byte(line))
-				}
-
-				log.Println("Event stream connection was closed. Re-opening...")
+				break
 			}
-		}()
-	}
+
+			if len(strings.TrimSpace(line)) == 0 {
+				continue
+			}
+
+			if !strings.HasPrefix(line, "data: ") {
+				errorMsg := "Wrong event format: %s\n"
+				log.Printf(errorMsg, line)
+				continue
+			}
+
+			line = line[6:]
+			payloadChan <- []byte(line)
+		}
+
+		log.Println("Event stream connection was closed. Re-opening...")
+	}()
+
+	return payloadChan
 }
 
 func configureLog() {

--- a/main/bamboo/bamboo_test.go
+++ b/main/bamboo/bamboo_test.go
@@ -66,6 +66,8 @@ func TestConnectToMarathonEventStream(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
 			server := httptest.NewServer(test.handler)
 			defer server.Close()
 
@@ -176,6 +178,8 @@ func TestListenToMarathonEventStream(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			stubSink := &stubEventSink{}
 			ticker := make(chan time.Time)
 

--- a/main/bamboo/bamboo_test.go
+++ b/main/bamboo/bamboo_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func eventSourceHandler(lines ...string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		for _, l := range lines {
+			fmt.Fprintln(w, l)
+		}
+	})
+}
+
+func TestConnectToMarathonEventStream(t *testing.T) {
+	for _, test := range []struct {
+		desc     string
+		user     string
+		password string
+		handler  http.Handler
+		count    int
+		payloads [][]byte
+	}{
+		{
+			desc: "not-found",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}),
+		},
+		{
+			desc:    "single-payload",
+			handler: eventSourceHandler("data: payload"),
+			count:   1,
+			payloads: [][]byte{
+				[]byte("payload\n"),
+			},
+		},
+		{
+			desc:    "heartbeat",
+			handler: eventSourceHandler("", "", ""),
+			count:   0,
+		},
+		{
+			desc:    "event line",
+			handler: eventSourceHandler("event: eventName"),
+			count:   0,
+		},
+		{
+			desc:    "mixed content",
+			handler: eventSourceHandler("", "event: eventName", "data: payload", "", "", "event: eventName2", "data: payload2", ""),
+			count:   2,
+			payloads: [][]byte{
+				[]byte("payload\n"),
+				[]byte("payload2\n"),
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+
+			ch := connectToMarathonEventStream(server.URL, test.user, test.password)
+
+			count := 0
+			for p := range ch {
+				count++
+
+				if count > len(test.payloads) {
+					t.Errorf("got payload %s, but wanted none", p)
+					continue
+				}
+
+				expected := test.payloads[count-1]
+				if !reflect.DeepEqual(p, expected) {
+					t.Errorf("got payload %s, wanted %s", p, expected)
+				}
+			}
+
+			if count != test.count {
+				t.Errorf("got %d payloads, wanted %d", count, test.count)
+			}
+		})
+	}
+
+	t.Run("url-error", func(t *testing.T) {
+		ch := connectToMarathonEventStream("unknown://", "", "")
+
+		count := 0
+		for _ = range ch {
+			count++
+		}
+
+		if count != 0 {
+			t.Errorf("got %d payloads, wanted none", count)
+		}
+	})
+
+	t.Run("request-error", func(t *testing.T) {
+		server := httptest.NewServer(nil)
+		server.Close()
+
+		ch := connectToMarathonEventStream(server.URL, "", "")
+
+		count := 0
+		for _ = range ch {
+			count++
+		}
+
+		if count != 0 {
+			t.Errorf("got %d payloads, wanted none", count)
+		}
+	})
+}


### PR DESCRIPTION
While preparing #225 I noticed that the event stream loop did not have any tests.

This PR also fixes two issues I noticed while passing:
- Having an invalid URL for the event stream will crash bamboo, because the old code tries to set the `Accept` header before checking the `err` value.
- Starting three goroutines each having a connection to the event stream seemed not correct. I have changed this so that only one event stream connection is opened but when that one fails the other servers are tried in turn (with a second wait in between) so that when one server fails the connection is recovered.

This PR will conflict with #225 so if one of the two is merged the other will need to be rebased which I will happily do.