### PR TITLE
Expose ToInt conversion for usage in template

### DIFF
--- a/services/template/template.go
+++ b/services/template/template.go
@@ -5,7 +5,7 @@ import (
 	"github.com/QubitProducts/bamboo/services/service"
 	"strconv"
 	"strings"
-	"text/template"	
+	"text/template"
 )
 
 func hasKey(data map[string]service.Service, appId string) bool {

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -3,9 +3,9 @@ package template
 import (
 	"bytes"
 	"github.com/QubitProducts/bamboo/services/service"
-	"strings"
-	"text/template"
 	"strconv"
+	"strings"
+	"text/template"	
 )
 
 func hasKey(data map[string]service.Service, appId string) bool {

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -5,6 +5,7 @@ import (
 	"github.com/QubitProducts/bamboo/services/service"
 	"strings"
 	"text/template"
+	"strconv"
 )
 
 func hasKey(data map[string]service.Service, appId string) bool {
@@ -29,7 +30,8 @@ func RenderTemplate(templateName string, templateContent string, data interface{
 		"Join":       strings.Join,
 		"Replace":    strings.Replace,
 		"ToUpper":    strings.ToUpper,
-		"ToLower":    strings.ToLower}
+		"ToLower":    strings.ToLower,
+		"ToInt":      strconv.Atoi}
 
 	tpl := template.Must(template.New(templateName).Funcs(funcMap).Parse(templateContent))
 

--- a/services/template/template_test.go
+++ b/services/template/template_test.go
@@ -96,3 +96,18 @@ func TestTemplateToLowerFunction(t *testing.T) {
 		})
 	})
 }
+
+func TestTemplateToIntFunction(t *testing.T) {
+        Convey("#RenderTemplate", t, func() {
+                templateName := "templateName"
+                domains := []string{"example.com", "example.net"}
+                params := map[string]interface{}{"idx": "1", "domains": domains}
+
+                templateContent := "{{index .domains (ToInt .idx)}}"
+                Convey("should transform an indexo to integer", func() {
+                        content, _ := RenderTemplate(templateName, templateContent, params)
+                        So(content, ShouldEqual, "example.net")
+                })
+        })
+}
+

--- a/services/template/template_test.go
+++ b/services/template/template_test.go
@@ -98,16 +98,15 @@ func TestTemplateToLowerFunction(t *testing.T) {
 }
 
 func TestTemplateToIntFunction(t *testing.T) {
-        Convey("#RenderTemplate", t, func() {
-                templateName := "templateName"
-                domains := []string{"example.com", "example.net"}
-                params := map[string]interface{}{"idx": "1", "domains": domains}
+	Convey("#RenderTemplate", t, func() {
+		templateName := "templateName"
+		domains := []string{"example.com", "example.net"}
+		params := map[string]interface{}{"idx": "1", "domains": domains}
 
-                templateContent := "{{index .domains (ToInt .idx)}}"
-                Convey("should transform an indexo to integer", func() {
-                        content, _ := RenderTemplate(templateName, templateContent, params)
-                        So(content, ShouldEqual, "example.net")
-                })
-        })
+		templateContent := "{{index .domains (ToInt .idx)}}"
+		Convey("should transform an indexo to integer", func() {
+			content, _ := RenderTemplate(templateName, templateContent, params)
+			So(content, ShouldEqual, "example.net")
+		})
+	})
 }
-


### PR DESCRIPTION
Allow usage of strconv.Atoi method in templates to convert environment variables to int for usage with the "index" method