### PR TITLE
Implement and expose ready state.

### DIFF
--- a/services/marathon/marathon_test.go
+++ b/services/marathon/marathon_test.go
@@ -1,8 +1,14 @@
 package marathon
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
+	"fmt"
 	"testing"
+
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/QubitProducts/bamboo/configuration"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestGetMesosDnsId_Simple(t *testing.T) {
@@ -62,4 +68,353 @@ func TestParseHealthCheckPathMixed(t *testing.T) {
 			So(parseHealthCheckPath(checks), ShouldEqual, "/path")
 		})
 	})
+}
+
+func TestParseJSONRequest(t *testing.T) {
+	tests := []struct {
+		user          string
+		password      string
+		wantBasicAuth bool
+	}{
+		{
+			wantBasicAuth: false,
+		},
+		{
+			user:          "user",
+			wantBasicAuth: false,
+		},
+		{
+			password:      "password",
+			wantBasicAuth: false,
+		},
+		{
+			user:          "user",
+			password:      "password",
+			wantBasicAuth: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("user='%s' password='%s'", test.user, test.password), func(t *testing.T) {
+			t.Parallel()
+			conf := configuration.Configuration{
+				Marathon: configuration.Marathon{
+					User:     test.user,
+					Password: test.password,
+				},
+			}
+
+			var req *http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				req = r
+				fmt.Fprint(w, "{}")
+			}))
+			defer ts.Close()
+
+			var res interface{}
+			err := parseJSON(ts.URL, &conf, &res)
+			if err != nil {
+				t.Fatalf("parseJSON returned error: %s", err)
+			}
+
+			if req.Method != http.MethodGet {
+				t.Errorf("got method '%s', want '%s'", req.Method, http.MethodGet)
+			}
+
+			for _, hdrKey := range []string{"Accept", "Content-Type"} {
+				hdrValue := req.Header.Get(hdrKey)
+				switch {
+				case hdrValue == "":
+					t.Errorf("%s header missing", hdrKey)
+				case hdrValue != "application/json":
+					t.Errorf("got %s header value '%s', want 'application/json'", hdrKey, hdrValue)
+				}
+			}
+
+			authHdrValue := req.Header.Get("Authorization")
+			if test.wantBasicAuth != (authHdrValue != "") {
+				t.Errorf("got Authorization header value '%s', wanted header: %t", authHdrValue, test.wantBasicAuth)
+			}
+		})
+	}
+}
+
+func TestParseJSONHandling(t *testing.T) {
+	tests := []struct {
+		desc          string
+		handler       http.Handler
+		shouldSucceed bool
+	}{
+		{
+			desc:          "request failed",
+			shouldSucceed: false,
+		},
+		{
+			desc: "invalid JSON",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprint(w, "{")
+			}),
+			shouldSucceed: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			var endpoint string
+			if test.handler != nil {
+				ts := httptest.NewServer(test.handler)
+				defer ts.Close()
+				endpoint = ts.URL
+			}
+
+			conf := configuration.Configuration{}
+			var res interface{}
+			err := parseJSON(endpoint, &conf, res)
+
+			if test.shouldSucceed != (err == nil) {
+				t.Errorf("got error '%s', wanted error: %t", err, !test.shouldSucceed)
+			}
+		})
+	}
+}
+
+func TestFetchApps(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{
+	"apps": [
+		{
+			"id": "/app2WithSlash",
+			"tasks": [
+				{
+					"id": "task2",
+					"ports": [8002]
+				},
+				{
+					"id": "task1",
+					"ports": [8001]
+				}
+			]
+		},
+		{
+			"id": "app1WithoutSlash",
+			"tasks": [
+				{
+					"id": "task1",
+					"ports": [8001]
+				},
+				{
+					"id": "task2",
+					"ports": [8002]
+				}
+			]
+		}
+	]
+}`)
+	}))
+	defer ts.Close()
+
+	// First Marathon URL is invalid to verify failover behavior.
+	maraConf := configuration.Marathon{
+		Endpoint: fmt.Sprintf("http://127.0.0.1:4242,%s", ts.URL),
+	}
+
+	apps, err := FetchApps(maraConf, &configuration.Configuration{})
+
+	if err != nil {
+		t.Fatalf("FetchApps returned error: %s", err)
+	}
+
+	if len(apps) < 1 {
+		t.Fatal("no apps fetched")
+	}
+	assertFetchedApp(t, 1, "/app1WithoutSlash", apps[0])
+
+	if len(apps) < 2 {
+		t.Fatal("missing second app")
+	}
+	assertFetchedApp(t, 2, "/app2WithSlash", apps[1])
+
+	if len(apps) > 2 {
+		t.Fatalf("got %d apps, want 2", len(apps))
+	}
+}
+
+func TestCalculateReadiness(t *testing.T) {
+	tests := []struct {
+		desc      string
+		task      marathonTask
+		app       marathonApp
+		wantReady bool
+	}{
+		{
+			desc: "non-running task",
+			task: marathonTask{
+				State: "TASK_STAGED",
+			},
+			wantReady: false,
+		},
+		{
+			desc: "no deployment running for app",
+			task: marathonTask{
+				State: taskStateRunning,
+			},
+			app: marathonApp{
+				Deployments: []deployment{},
+			},
+			wantReady: true,
+		},
+		{
+			desc: "no readiness checks defined for app",
+			task: marathonTask{
+				State: taskStateRunning,
+			},
+			app: marathonApp{
+				Deployments: []deployment{
+					deployment{ID: "deploymentId"},
+				},
+				ReadinessChecks: []marathonReadinessCheck{},
+			},
+			wantReady: true,
+		},
+		{
+			desc: "readiness check result negative",
+			task: marathonTask{
+				Id:    "taskId",
+				State: taskStateRunning,
+			},
+			app: marathonApp{
+				Deployments: []deployment{
+					deployment{ID: "deploymentId"},
+				},
+				ReadinessChecks: []marathonReadinessCheck{
+					marathonReadinessCheck{
+						Path: "/ready",
+					},
+				},
+				ReadinessCheckResults: []readinessCheckResult{
+					readinessCheckResult{
+						Ready:  false,
+						TaskID: "taskId",
+					},
+				},
+			},
+			wantReady: false,
+		},
+		{
+			desc: "readiness check result positive",
+			task: marathonTask{
+				Id:    "taskId",
+				State: taskStateRunning,
+			},
+			app: marathonApp{
+				Deployments: []deployment{
+					deployment{ID: "deploymentId"},
+				},
+				ReadinessChecks: []marathonReadinessCheck{
+					marathonReadinessCheck{
+						Path: "/ready",
+					},
+				},
+				ReadinessCheckResults: []readinessCheckResult{
+					readinessCheckResult{
+						Ready:  false,
+						TaskID: "otherTaskId",
+					},
+					readinessCheckResult{
+						Ready:  true,
+						TaskID: "taskId",
+					},
+				},
+			},
+			wantReady: true,
+		},
+		{
+			desc: "ready task's readiness check result outstanding",
+			task: marathonTask{
+				Id:      "newTaskId",
+				State:   taskStateRunning,
+				Version: "2017-01-15T00:00:00.000Z",
+			},
+			app: marathonApp{
+				Deployments: []deployment{
+					deployment{ID: "deploymentId"},
+				},
+				ReadinessChecks: []marathonReadinessCheck{
+					marathonReadinessCheck{
+						Path: "/ready",
+					},
+				},
+				ReadinessCheckResults: []readinessCheckResult{},
+				Tasks: marathonTaskList{
+					marathonTask{
+						Id:      "newTaskId",
+						Version: "2017-01-15T00:00:00.000Z",
+					},
+					marathonTask{
+						Id:      "oldTaskId",
+						Version: "2017-01-01T00:00:00.000Z",
+					},
+				},
+			},
+			wantReady: false,
+		},
+		{
+			desc: "task not involved in deployment",
+			task: marathonTask{
+				Id:      "oldTaskId",
+				State:   taskStateRunning,
+				Version: "2017-01-01T00:00:00.000Z",
+			},
+			app: marathonApp{
+				Deployments: []deployment{
+					deployment{ID: "deploymentId"},
+				},
+				ReadinessChecks: []marathonReadinessCheck{
+					marathonReadinessCheck{
+						Path: "/ready",
+					},
+				},
+				ReadinessCheckResults: []readinessCheckResult{},
+				Tasks: marathonTaskList{
+					marathonTask{
+						Id:      "newTaskId",
+						Version: "2017-01-15T00:00:00.000Z",
+					},
+					marathonTask{
+						Id:      "oldTaskId",
+						Version: "2017-01-01T00:00:00.000Z",
+					},
+				},
+			},
+			wantReady: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			gotReady := calculateReadiness(test.task, test.app)
+			if gotReady != test.wantReady {
+				t.Errorf("got ready = %t, want ready = %t", gotReady, test.wantReady)
+			}
+		})
+	}
+}
+
+func assertFetchedApp(t *testing.T, index int, id string, app App) {
+	if app.Id != id {
+		t.Errorf("app #%d: got app ID '%s', want '%s'", index, app.Id, id)
+	}
+	switch {
+	case len(app.Tasks) != 2:
+		t.Errorf("app #%d: got %d tasks, want 2", index, len(app.Tasks))
+	case app.Tasks[0].Id != "task1":
+		t.Errorf("app #%d: got ID '%s' for task #1, want 'task1", index, app.Tasks[0].Id)
+	case app.Tasks[1].Id != "task2":
+		t.Errorf("app #%d: got ID '%s' for task #2, want 'task2", index, app.Tasks[1].Id)
+	}
 }


### PR DESCRIPTION
During deployments (only), we mark applications as ready depending on the outcome of potentially configured readiness checks.

The change goes along with some major refactoring, primarily focused towards retrieving all necessary state from a single Marathon API request thanks to the `embed=apps.tasks{deployments,readiness}` query parameter. This is necessary in order to retrieve a single, consistent app/task state not skewed by two API requests send away at slightly different offsets.

Additionally, we stop considering tasks as ready which have not yet reached the `TASK_RUNNING` state since still staging or otherwise non-ready tasks are bound to fail if taken into load-balancing rotation prematurely.

In order to leverage the new `Ready` state, one would have to adjust the HAProxy template. What we did was wrap [the line adding a single server](https://github.com/QubitProducts/bamboo/blob/7acac5a2c4d0f7af165f743b134f0b09058795c9/config/haproxy_template.cfg#L64) with something like this

```
{{- if .Ready }}
  <the line referenced above; see explanation below though>
{{- end }}{{/* if .Ready */}}
```

I didn't include the change to the template in this PR since it seems to be an individual decision what gets put into the HAProxy health check option. For instance, in our cluster, we use the readiness check path if it's available and otherwise fall back to the health check. I was unsure on whether that should be included in the PR, or if an explanation in the documentation might be preferable. Personally, I'm leaning towards the latter.

Happy to make further adjustments in this (or any other) regard if you let me know.

The PR refs #230 but supersedes the [solution I described there](https://github.com/QubitProducts/bamboo/issues/230#issuecomment-290949509) since the readiness check takes `TASK_KILLING` into consideration implicitly.