### PR TITLE
add ipAddress to support docker network like macvlan

### DIFF
--- a/services/marathon/marathon_test.go
+++ b/services/marathon/marathon_test.go
@@ -189,10 +189,12 @@ func TestFetchApps(t *testing.T) {
 			"id": "/app2WithSlash",
 			"tasks": [
 				{
+					"host":"localhost",
 					"id": "task2",
 					"ports": [8002]
 				},
 				{
+					"host":"localhost",
 					"id": "task1",
 					"ports": [8001]
 				}
@@ -202,12 +204,46 @@ func TestFetchApps(t *testing.T) {
 			"id": "app1WithoutSlash",
 			"tasks": [
 				{
+					"host":"localhost",
 					"id": "task1",
 					"ports": [8001]
 				},
 				{
+					"host":"localhost",
 					"id": "task2",
 					"ports": [8002]
+				}
+			]
+		},
+		{
+			"id": "app3WithIpAddress",
+			"ipAddress": {
+				"discovery":{
+					"ports": [
+						{
+							"number": 80	
+						}
+					]
+				}	
+			},
+			"tasks": [
+				{
+					"host":"localhost",
+					"ipAddresses":[
+						{
+							"ipAddress": "127.0.0.1"
+						}
+					],
+					"id": "task1"
+				},
+				{
+					"host":"localhost",
+					"ipAddresses":[
+						{
+							"ipAddress": "127.0.0.1"
+						}
+					],
+					"id": "task2"
 				}
 			]
 		}
@@ -237,8 +273,13 @@ func TestFetchApps(t *testing.T) {
 	}
 	assertFetchedApp(t, 2, "/app2WithSlash", apps[1])
 
-	if len(apps) > 2 {
-		t.Fatalf("got %d apps, want 2", len(apps))
+	if len(apps) < 3 {
+		t.Fatal("missing third app")
+	}
+	assertFetchedApp(t, 3, "/app3WithIpAddress", apps[2])
+
+	if len(apps) > 3 {
+		t.Fatalf("got %d apps, want 3", len(apps))
 	}
 }
 


### PR DESCRIPTION
When  craeting an app with with docker macvlan network in marathon，there is two steps we may do bellow:  reference: https://docs.docker.com/engine/userguide/networking/get-started-macvlan/

1. create docker macvlan network

      	docker network create -d macvlan --subnet=192.168.1.0/24 --gateway=192.168.1.1 --ip-range=192.168.1.128/28 -o parent=eth0 -o macvlan_mode=bridge macvlan0
      
2. deploy an app with json

       {
  		"id": "macvlan-2048",
  		"cmd": null,
  		"cpus": 0.1,
  		"mem": 128,
  		"disk": 0,
  		"instances": 1,
  		"container": {
    	"docker": {
      		"image": "",
      		"network": "HOST",
      		"parameters": [
		{
          "key": "net",
          "value": "macvlan0"
        }
        ]
    	},
    	"type": "DOCKER"
  		},
  		"ipAddress":{
			"discovery":{
				"ports":[
		    		{
					"number":80,
					"name":"http",
					"protocol":"tcp"
		    		}
					]
				}
  			}
		}
		
this PR add IpAddress field and update the createApps function to support app with macvlan network 