### PR TITLE
Calculate readiness for tasks without checks based on start time.

### DIFF
--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -70,7 +70,9 @@ backend {{ $app.EscapedId }}-cluster{{ if $app.HealthCheckPath }}
         option httpclose
         option forwardfor
         {{ range $page, $task := .Tasks }}
+        # {{ if .Ready }}  ### Comment in to only put ready tasks into rotation.
         server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ if eq $app.HealthCheckProtocol "HTTPS" }} ssl verify none {{ end }} {{ end }}
+        # {{ end }}{{/* if .Ready */}}  ### Comment in to only put ready tasks into rotation.
 {{ end }}
 
 ##


### PR DESCRIPTION
This closes a readiness calculation gap where brand new tasks from an initially deployed application and long-running tasks part of a rolling-upgrade (with all new tasks of the deployment having crashed momentarily and not be included in the API response) could not be distinguished properly if readiness check results were also missing for a task in question.

We solve the problem by looking at the age of a task: If its start time is still within the timeout period of the configured readiness check probe, we consider the task to be a new one and mark it as unready. Otherwise, we assume the task to be a long-running one and mark it as ready.

The new approach supersedes the one based on the number of task versions available introduced in commit 767b0d12ee5da703e414a797815a4932031372ef.

Finally, we extend the HAProxy template by a (commented out) if-guard taking task readiness into account.